### PR TITLE
Remove Tailwind safelists

### DIFF
--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -1,12 +1,6 @@
 /** @type {import('tailwindcss').Config} */
 module.exports = {
   content: ["./pages/**/*.{js,ts,jsx,tsx}", "./components/**/*.{js,ts,jsx,tsx}"],
-  safelist: [
-    {
-      pattern: /order-/,
-      variants: ["sm"],
-    },
-  ],
   theme: {
     extend: {
       colors: {


### PR DESCRIPTION
- The `order-*` className is no longer needed since the welcome page was changed in 1fda047.

- Including the "sm" variant added *every* `*-sm` to the CSS. This resulted in large CSS and long compile times in development. I don't see anywhere that we dynamically create an `*-sm` className (any more), so it should be safe to remove.

**Before**

```
event - compiled client and server successfully in 19.2s (543 modules)
```

**After**

```
event - compiled client and server successfully in 732 ms (593 modules)
```

Closes #75