### PR TITLE
alternative layout and styling

### DIFF
--- a/frontend/components/wiki/aside.jsx
+++ b/frontend/components/wiki/aside.jsx
@@ -1,6 +1,6 @@
-import React, { Fragment } from "react";
 import Link from "next/link";
 import PropTypes from "prop-types";
+import React, { Fragment } from "react";
 
 function Document({ item }) {
   const url =
@@ -48,11 +48,8 @@ Folder.propTypes = {
 
 export default function Aside({ posts }) {
   return (
-    <aside className="min-w-[250px] ">
-      <h4 className="my-4 basis-full border-l-[0.75rem] border-b-2 border-holon-blue-900 pl-3 text-xl font-light">
-        Menu
-      </h4>
-      <div className="bg-holon-gold-200">
+    <aside className="mx-3 mt-10">
+      <div className="">
         {posts.map((item, index) =>
           item.children.length < 1 ? (
             <Document key={index} item={item} />

--- a/frontend/components/wiki/breadcrumbs.jsx
+++ b/frontend/components/wiki/breadcrumbs.jsx
@@ -1,6 +1,5 @@
 import Link from "next/link";
-import React from "react";
-import { useEffect, useState } from "react";
+import React, { useEffect, useState } from "react";
 
 export default function Breadcrumbs(props) {
   const [breadcrumbs, setBreadcrumbs] = useState([]);
@@ -20,7 +19,7 @@ export default function Breadcrumbs(props) {
       : setBreadcrumbs(breadcrumbarray);
   }
   return (
-    <nav className="mb-8 flex flex-row justify-center bg-holon-gold-600 py-2">
+    <nav className="flex flex-row justify-center py-2">
       <ul className="container flex flex-row justify-start gap-3">
         <li>
           <Link href="/wiki/">Holon</Link>
@@ -29,14 +28,22 @@ export default function Breadcrumbs(props) {
           const url = !breadcrumbitem.url
             ? ""
             : breadcrumbitem.url.indexOf("index.mdx") > 0
-            ? breadcrumbitem.url.replace(/\index\.mdx$/, "")
+            ? " > " + breadcrumbitem.url.replace(/\index\.mdx$/, "")
             : breadcrumbitem.url.replace(/\.mdx$/, "");
           return (
             <li key={index}>
               {url ? (
-                <Link href={"/wiki/" + url}>{breadcrumbitem.name}</Link>
+                <Link href={"/wiki/" + url}>
+                  <span>
+                    <span className="mr-3 text-gray-600">{"/"}</span>
+                    {breadcrumbitem.name}
+                  </span>
+                </Link>
               ) : (
-                <span>{breadcrumbitem}</span>
+                <span>
+                  <span className="mr-3 text-gray-600">{"/"}</span>
+                  <span className="font-bold text-holon-gold-600">{breadcrumbitem}</span>
+                </span>
               )}
             </li>
           );

--- a/frontend/pages/_wiki.jsx
+++ b/frontend/pages/_wiki.jsx
@@ -1,3 +1,4 @@
+import { BookOpenIcon } from "@heroicons/react/solid";
 import PropTypes from "prop-types";
 import React, { useEffect, useState } from "react";
 import Aside from "../components/wiki/aside";
@@ -14,18 +15,28 @@ export default function DocsLayout({ children }) {
 
   return (
     <React.Fragment>
-      <div className="flex w-full flex-col">
-        <header className="flex flex-row justify-center bg-holon-blue-900">
-          <h1 className="container py-2 text-3xl font-bold text-white">Holon Wiki</h1>
-        </header>
-        {posts && currentpage && <Breadcrumbs currentpage={currentpage} posts={posts} />}
-
-        <main className="flex flex-row justify-center">
-          <div className="container flex flex-row gap-x-40">
-            {posts && <Aside currentpage={currentpage} posts={posts} />}
-            <article className="prose">{children}</article>
+      <div className="min-h-screen min-w-full">
+        <header className="flex h-[8vh] flex-row justify-start overflow-hidden bg-holon-blue-900 align-middle">
+          <div className="flex w-3/12 justify-center justify-items-center">
+            <a href="/wiki/" className="flex flex-row">
+              <BookOpenIcon className="h-10 w-10 self-center text-white" />
+              <h1 className="ml-2 self-center py-2 text-3xl font-bold text-white">Holon Wiki</h1>
+            </a>
           </div>
-        </main>
+        </header>
+
+        <div className="flex min-h-[92vh] w-full flex-row">
+          <div className="bottom-0 flex w-3/12 flex-col overflow-hidden border-2 border-gray-200">
+            {posts && <Aside currentpage={currentpage} posts={posts} />}
+          </div>
+
+          <main className="h-[92vh] w-9/12 overflow-auto">
+            <div className="border-b-2 border-gray-200 py-3 pl-10">
+              {posts && <Breadcrumbs currentpage={currentpage} posts={posts} />}
+            </div>
+            <article className="prose mt-5 ml-10 mb-16">{children}</article>
+          </main>
+        </div>
       </div>
     </React.Fragment>
   );

--- a/frontend/pages/wiki/Sociaal/Gedrag/content.mdx
+++ b/frontend/pages/wiki/Sociaal/Gedrag/content.mdx
@@ -1,0 +1,1 @@
+# Welkom bij dit artikel in deze subsubmap 

--- a/frontend/pages/wiki/This is markdown.mdx
+++ b/frontend/pages/wiki/This is markdown.mdx
@@ -35,8 +35,8 @@ An image from the `/public` dir:
 
 ![](/imgs/cookie.png)
 
-| Time | Value |
-| ---- | ----- |
-| 00:00 | 0 |
-| 01:00 | 1 |
-| 02:00 | 2 |
+| Time  | Value |
+| ----- | ----- |
+| 00:00 | 0     |
+| 01:00 | 1     |
+| 02:00 | 2     |

--- a/frontend/pages/wiki/index.md
+++ b/frontend/pages/wiki/index.md
@@ -1,0 +1,241 @@
+# Welkom!
+Goed dat je de Holon wikipedia gevonden hebt! Hier vertellen we je graag meer over dit project, relevante onderwerpen en de achtergrond bij verschillende uitdagingen voor de energietransitie. We gebruiken voor het het onderzoeken van **semi-autonome energiesystemen** niet alleen technische en kwantitatieve overwegingen maar houden ook rekening met toepasselijke **sociale**, **juridische** en **financiële** beperkingen.
+
+#### Hieronder een demo van hoe Markdown werkt:
+---
+
+
+
+# h1 Heading
+## h2 Heading
+### h3 Heading
+#### h4 Heading
+##### h5 Heading
+###### h6 Heading
+
+
+## Horizontal Rules
+
+___
+
+---
+
+***
+
+
+## Typographic replacements
+
+Enable typographer option to see result.
+
+(c) (C) (r) (R) (tm) (TM) (p) (P) +-
+
+test.. test... test..... test?..... test!....
+
+!!!!!! ???? ,,  -- ---
+
+"Smartypants, double quotes" and 'single quotes'
+
+
+## Emphasis
+
+**This is bold text**
+
+__This is bold text__
+
+*This is italic text*
+
+_This is italic text_
+
+~~Strikethrough~~
+
+
+## Blockquotes
+
+
+> Blockquotes can also be nested...
+>> ...by using additional greater-than signs right next to each other...
+> > > ...or with spaces between arrows.
+
+
+## Lists
+
+Unordered
+
++ Create a list by starting a line with `+`, `-`, or `*`
++ Sub-lists are made by indenting 2 spaces:
+  - Marker character change forces new list start:
+    * Ac tristique libero volutpat at
+    + Facilisis in pretium nisl aliquet
+    - Nulla volutpat aliquam velit
++ Very easy!
+
+Ordered
+
+1. Lorem ipsum dolor sit amet
+2. Consectetur adipiscing elit
+3. Integer molestie lorem at massa
+
+
+1. You can use sequential numbers...
+1. ...or keep all the numbers as `1.`
+
+Start numbering with offset:
+
+57. foo
+1. bar
+
+
+## Code
+
+Inline `code`
+
+Indented code
+
+    // Some comments
+    line 1 of code
+    line 2 of code
+    line 3 of code
+
+
+Block code "fences"
+
+```
+Sample text here...
+```
+
+Syntax highlighting
+
+``` js
+var foo = function (bar) {
+  return bar++;
+};
+
+console.log(foo(5));
+```
+
+## Tables
+
+| Option | Description                                                               |
+| ------ | ------------------------------------------------------------------------- |
+| data   | path to data files to supply the data that will be passed into templates. |
+| engine | engine to be used for processing templates. Handlebars is the default.    |
+| ext    | extension to be used for dest files.                                      |
+
+Right aligned columns
+
+| Option |                                                               Description |
+| -----: | ------------------------------------------------------------------------: |
+|   data | path to data files to supply the data that will be passed into templates. |
+| engine |    engine to be used for processing templates. Handlebars is the default. |
+|    ext |                                      extension to be used for dest files. |
+
+
+## Links
+
+[link text](http://dev.nodeca.com)
+
+[link with title](http://nodeca.github.io/pica/demo/ "title text!")
+
+Autoconverted link https://github.com/nodeca/pica (enable linkify to see)
+
+
+## Images
+
+![Minion](https://octodex.github.com/images/minion.png)
+![Stormtroopocat](https://octodex.github.com/images/stormtroopocat.jpg "The Stormtroopocat")
+
+Like links, Images also have a footnote style syntax
+
+![Alt text][id]
+
+With a reference later in the document defining the URL location:
+
+[id]: https://octodex.github.com/images/dojocat.jpg  "The Dojocat"
+
+
+## Plugins
+
+The killer feature of `markdown-it` is very effective support of
+[syntax plugins](https://www.npmjs.org/browse/keyword/markdown-it-plugin).
+
+
+### [Emojies](https://github.com/markdown-it/markdown-it-emoji)
+
+> Classic markup: :wink: :crush: :cry: :tear: :laughing: :yum:
+>
+> Shortcuts (emoticons): :-) :-( 8-) ;)
+
+see [how to change output](https://github.com/markdown-it/markdown-it-emoji#change-output) with twemoji.
+
+
+### [Subscript](https://github.com/markdown-it/markdown-it-sub) / [Superscript](https://github.com/markdown-it/markdown-it-sup)
+
+- 19^th^
+- H~2~O
+
+
+### [\<ins>](https://github.com/markdown-it/markdown-it-ins)
+
+++Inserted text++
+
+
+### [\<mark>](https://github.com/markdown-it/markdown-it-mark)
+
+==Marked text==
+
+
+### [Footnotes](https://github.com/markdown-it/markdown-it-footnote)
+
+Footnote 1 link[^first].
+
+Footnote 2 link[^second].
+
+Inline footnote^[Text of inline footnote] definition.
+
+Duplicated footnote reference[^second].
+
+[^first]: Footnote **can have markup**
+
+    and multiple paragraphs.
+
+[^second]: Footnote text.
+
+
+### [Definition lists](https://github.com/markdown-it/markdown-it-deflist)
+
+Term 1
+
+:   Definition 1
+with lazy continuation.
+
+Term 2 with *inline markup*
+
+:   Definition 2
+
+        { some code, part of Definition 2 }
+
+    Third paragraph of definition 2.
+
+_Compact style:_
+
+Term 1
+  ~ Definition 1
+
+Term 2
+  ~ Definition 2a
+  ~ Definition 2b
+
+
+### [Abbreviations](https://github.com/markdown-it/markdown-it-abbr)
+
+This is HTML abbreviation example.
+
+It converts "HTML", but keep intact partial entries like "xxxHTMLyyy" and so on.
+
+*[HTML]: Hyper Text Markup Language
+
+### [Custom containers](https://github.com/markdown-it/markdown-it-container)
+
+::: warning
+*here be dragons*
+:::

--- a/frontend/pages/wiki/this_is_markdown.mdx
+++ b/frontend/pages/wiki/this_is_markdown.mdx
@@ -1,0 +1,42 @@
+# My MDX page
+
+Cupcake ipsum dolor sit amet toffee liquorice marshmallow. Bonbon chocolate bar biscuit marshmallow
+danish lollipop cookie icing. Pudding powder cupcake wafer wafer donut tootsie roll cotton candy
+tootsie roll. Ice cream danish powder oat cake lollipop oat cake topping.
+
+Cupcake cheesecake caramels candy canes cotton candy sweet. Pastry tiramisu chocolate candy caramels
+cupcake dessert jelly apple pie. Pastry tart jujubes muffin tootsie roll tiramisu sweet roll. Chupa
+chups dessert halvah ice cream sweet roll muffin oat cake.
+
+This is a list in markdown:
+
+- One
+- Two
+- Three
+
+> This is a quote
+
+And some code:
+
+```ts
+const withMDX = require("@next/mdx")({
+  extension: /\.mdx?$/,
+  options: {
+    remarkPlugins: [require("remark-prism")],
+  },
+});
+
+module.exports = withMDX({
+  pageExtensions: ["js", "jsx", "mdx"],
+});
+```
+
+An image from the `/public` dir:
+
+![](/imgs/cookie.png)
+
+| Time  | Value |
+| ----- | ----- |
+| 00:00 | 0     |
+| 01:00 | 1     |
+| 02:00 | 2     |


### PR DESCRIPTION
Some alternatives to the current styling and layout of the wiki

1. Breadcrumb separated by "/" and on top of article

![image](https://user-images.githubusercontent.com/78690362/186640950-2a819302-d2ab-40e2-8879-d518ed961fa6.png)

3. Only the `div` with the `prose` (aka the article) has scroll overflow. The rest is locked to match `100 vh`, with `8 vh` for the header.

![image](https://user-images.githubusercontent.com/78690362/186641133-7961fb53-3b00-43d4-9b98-c8931fe0dec5.png)

3. Book icon with `span` and `href` in the header