### PR TITLE
Fetch only storyline childs instead of all

### DIFF
--- a/src/main/pages/storylineoverview_serializer.py
+++ b/src/main/pages/storylineoverview_serializer.py
@@ -11,7 +11,7 @@ class StorylineOverviewPageSerializer(BasePageSerializer):
     all_information_types = serializers.SerializerMethodField()
 
     def get_all_storylines(self, page):
-        all = StorylinePage.objects.all()
+        all = StorylinePage.objects.descendant_of(page)
         return_all_storylines = []
         for sl in all:
             roles_array = []


### PR DESCRIPTION
Only fetch the children (that are always storylines) of a specific storylineoverviewpage instead of all storylines