### PR TITLE
Fixes TypeScript for Pipit components and adds some tests

### DIFF
--- a/frontend/cli/__Class/__Class.tsx
+++ b/frontend/cli/__Class/__Class.tsx
@@ -1,4 +1,4 @@
-import React, { PureComponent } from 'react';
+import { PureComponent } from 'react';
 
 // import i18n from '../../i18n';
 // import PropTypes from 'prop-types';
@@ -7,10 +7,6 @@ import styles from './__Class.module.css';
 
 class __Class extends PureComponent {
     state = {};
-
-    static defaultProps = {};
-
-    static propTypes = {};
 
     render() {
         return <div className={styles['__Class']}>__Class</div>;

--- a/frontend/cli/__Pure/__Pure.tsx
+++ b/frontend/cli/__Pure/__Pure.tsx
@@ -1,13 +1,6 @@
-import React from 'react';
-
 // import i18n from '../../i18n';
-// import PropTypes from 'prop-types';
 import styles from './__Pure.module.css';
 
 const __Pure = () => <div className={styles['__Pure']}>__Pure</div>;
-
-__Pure.propTypes = {};
-
-__Pure.defaultProps = {};
 
 export default __Pure;

--- a/frontend/components/Blocks/HeroBlock/HeroBlock.test.tsx
+++ b/frontend/components/Blocks/HeroBlock/HeroBlock.test.tsx
@@ -1,0 +1,119 @@
+import { render, screen } from "@testing-library/react";
+import { act } from "react-dom/test-utils";
+import HeroBlock from "./";
+
+describe("<HeroBlock />", () => {
+  describe("with video media", () => {
+    beforeEach(async () => {
+      await act(() => {
+        render(
+          <HeroBlock
+            data={{
+              type: "unknown",
+              value: {
+                alt_text: "Some alt text",
+                backgroundColor: "bg-emerald-100",
+                media: [
+                  {
+                    type: "video",
+                    value: "/video",
+                    id: "",
+                    altText: "",
+                  },
+                ],
+                text: "Lorem ipsum",
+                title: "Hello world",
+              },
+              id: "a-hero-block",
+            }}
+          />
+        ).container;
+      });
+    });
+
+    it("renders a header", () => {
+      const heading = screen.getByRole("heading");
+
+      expect(heading.tagName).toEqual("H1");
+      expect(heading).toBeInTheDocument();
+      expect(heading).toHaveTextContent("Hello world");
+    });
+
+    it("renders text", () => {
+      const heading = screen.getByTestId("content");
+
+      expect(heading).toBeInTheDocument();
+      expect(heading).toHaveTextContent("Lorem ipsum");
+    });
+
+    it("renders text", () => {
+      const content = screen.getByTestId("content");
+
+      expect(content).toBeInTheDocument();
+      expect(content).toHaveTextContent("Lorem ipsum");
+    });
+
+    it("renders a video player", () => {
+      const media = screen.getByTestId("video-player");
+      expect(media).toBeInTheDocument();
+    });
+  });
+
+  describe("with image media", () => {
+    beforeEach(async () => {
+      await act(() => {
+        render(
+          <HeroBlock
+            data={{
+              type: "unknown",
+              value: {
+                alt_text: "Some alt text",
+                backgroundColor: "bg-emerald-100",
+                media: [
+                  {
+                    type: "image",
+                    value: {
+                      img: { src: "http://localhost:3000/video", width: 1, height: 1, alt: "Alt" },
+                      id: 1,
+                      title: "Some image",
+                    },
+                  },
+                ],
+                text: "Lorem ipsum",
+                title: "Hello world",
+              },
+              id: "a-hero-block",
+            }}
+          />
+        ).container;
+      });
+    });
+
+    it("renders a header", () => {
+      const heading = screen.getByRole("heading");
+
+      expect(heading.tagName).toEqual("H1");
+      expect(heading).toBeInTheDocument();
+      expect(heading).toHaveTextContent("Hello world");
+    });
+
+    it("renders text", () => {
+      const heading = screen.getByTestId("content");
+
+      expect(heading).toBeInTheDocument();
+      expect(heading).toHaveTextContent("Lorem ipsum");
+    });
+
+    it("renders text", () => {
+      const content = screen.getByTestId("content");
+
+      expect(content).toBeInTheDocument();
+      expect(content).toHaveTextContent("Lorem ipsum");
+    });
+
+    it("renders an image", () => {
+      const media = screen.getByRole("img");
+      expect(media).toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/components/Blocks/HeroBlock/HeroBlock.tsx
+++ b/frontend/components/Blocks/HeroBlock/HeroBlock.tsx
@@ -10,7 +10,7 @@ type Props = {
       backgroundColor: string;
       title: string;
       text: string;
-      media: [];
+      media: React.ComponentProps<typeof MediaContent>["media"];
       alt_text: string;
       button?: {
         button_style: string;
@@ -40,7 +40,7 @@ export default function HeroBlock({ data }: Props) {
             <h1>
               <RawHtml html={data.value.title}></RawHtml>
             </h1>
-            <div className={`font-normal mt-8 mr-8`}>
+            <div className={`font-normal mt-8 mr-8`} data-testid="content">
               <RawHtml html={data.value.text}></RawHtml>
             </div>
           </div>

--- a/frontend/components/Blocks/TitleBlock/TitleBlock.test.tsx
+++ b/frontend/components/Blocks/TitleBlock/TitleBlock.test.tsx
@@ -1,0 +1,34 @@
+import { render, screen } from "@testing-library/react";
+import TitleBlock from "./";
+
+describe("<TitleBlock />", () => {
+  beforeEach(() => {
+    render(
+      <TitleBlock
+        data={{
+          type: "unknown",
+          value: {
+            backgroundColor: "bg-emerald-100",
+            title: "Hello world",
+            size: "h2",
+            text: "Lorem ipsum",
+          },
+          id: "a-block",
+        }}
+      />
+    );
+  });
+
+  it("renders a header", () => {
+    const heading = screen.getByRole("heading");
+
+    expect(heading.tagName).toEqual("H2");
+    expect(heading).toBeInTheDocument();
+    expect(heading).toHaveTextContent("Hello world");
+  });
+
+  it("renders the text content", () => {
+    const content = screen.getByTestId("content");
+    expect(content).toHaveTextContent("Lorem ipsum");
+  });
+});

--- a/frontend/components/Blocks/TitleBlock/TitleBlock.tsx
+++ b/frontend/components/Blocks/TitleBlock/TitleBlock.tsx
@@ -20,8 +20,8 @@ export default function TitleBlock({ data }: Props) {
   return (
     <div className={`flex flex-row w-full h-fit py-12 px-10 lg:px-16 lg:pt-16 ${backgroundcolor}`}>
       <div className={`flex flex-col justify-start lg:mr-[40%]`}>
-        <Tag className={``}>{data.value.title}</Tag>
-        <div className="mt-6">
+        <Tag>{data.value.title}</Tag>
+        <div className="mt-6" data-testid="content">
           <RawHtml html={data.value?.text} />
         </div>
       </div>

--- a/frontend/components/MediaContent/MediaContent.tsx
+++ b/frontend/components/MediaContent/MediaContent.tsx
@@ -5,13 +5,13 @@ import Image from "next/future/image";
 type MediaDetails = {
   media: [
     | {
+        type: "video";
         id: string;
         value: string;
-        type: string;
         altText: string;
       }
     | {
-        type: string;
+        type: "image";
         value: {
           id: number;
           title: string;
@@ -40,22 +40,21 @@ export default function MediaContent({ media }: MediaDetails) {
     return null;
   }
 
-  function showMedia(mediaDetail) {
-    let returnValue = "";
+  function showMedia(mediaDetail: MediaDetails["media"][0]) {
     switch (mediaDetail.type) {
       case "video":
-        returnValue = mediaDetail.value && hasWindow && (
+        return mediaDetail.value && hasWindow ? (
           <ReactPlayer
             width="100%"
             height="440px"
-            key={`player ${mediaDetail.value.id}`}
+            key={mediaDetail.value.id}
             url={mediaDetail.value}
             controls={true}
+            data-testid="video-player"
           />
-        );
-        break;
+        ) : null;
       case "image":
-        returnValue = mediaDetail.value && (
+        return mediaDetail.value ? (
           <Image
             src={mediaDetail.value.img.src}
             alt={mediaDetail.value.img.alt}
@@ -63,10 +62,12 @@ export default function MediaContent({ media }: MediaDetails) {
             width="1600"
             height="900"
           />
+        ) : (
+          ""
         );
-      default:
     }
-    return returnValue;
+
+    return null;
   }
 
   // for now it is only possible to show one mediaitem (image or video).

--- a/frontend/components/RawHtml/RawHtml.tsx
+++ b/frontend/components/RawHtml/RawHtml.tsx
@@ -1,17 +1,8 @@
-import React from 'react';
-import PropTypes from 'prop-types';
-import s from './RawHtml.module.css';
+import React from "react";
+import s from "./RawHtml.module.css";
 
-const RawHtml = ({ html }) => (
-    <div className={s.Container} dangerouslySetInnerHTML={{ __html: html }} />
+const RawHtml = ({ html }: { html: string }) => (
+  <div className={s.Container} dangerouslySetInnerHTML={{ __html: html }} />
 );
-
-RawHtml.propTypes = {
-    html: PropTypes.string.isRequired,
-};
-
-RawHtml.defaultProps = {
-    html: '',
-};
 
 export default RawHtml;

--- a/frontend/components/VersionOne/Hero/Hero.tsx
+++ b/frontend/components/VersionOne/Hero/Hero.tsx
@@ -2,12 +2,11 @@
 
 import React from "react";
 import Image from "next/image";
-import PropTypes from "prop-types";
 
 import s from "./Hero.module.css";
 import logo from "../../../public/img/logo.svg";
 
-const Hero = ({ title }) => (
+const Hero = ({ title }: { title: string }) => (
   <div className={s.Container}>
     <Image src={logo} width="100" height="100" className={s.Logo} alt="Holon" />
     <h1 className={s.Title}>
@@ -17,13 +16,5 @@ const Hero = ({ title }) => (
     </h1>
   </div>
 );
-
-Hero.propTypes = {
-  title: PropTypes.string.isRequired,
-};
-
-Hero.defaultProps = {
-  title: "",
-};
 
 export default Hero;

--- a/frontend/components/WagtailUserbar/WagtailUserbar.tsx
+++ b/frontend/components/WagtailUserbar/WagtailUserbar.tsx
@@ -1,7 +1,6 @@
 import React, { useEffect } from 'react';
-import PropTypes from 'prop-types';
 
-const WagtailUserbar = ({ html }) => {
+const WagtailUserbar = ({ html }: { html: string }) => {
     useEffect(() => {
         // This  code is copy pasted from
         // https://github.com/wagtail/wagtail/blob/19ad01ddd5d051230318a2bbfa890ac5290f295a/client/src/entrypoints/admin/userbar.js
@@ -252,10 +251,6 @@ const WagtailUserbar = ({ html }) => {
     });
 
     return <div dangerouslySetInnerHTML={{ __html: html }} />;
-};
-
-WagtailUserbar.propTypes = {
-    html: PropTypes.string.isRequired,
 };
 
 export default WagtailUserbar;

--- a/frontend/containers/BasePage/BasePage.tsx
+++ b/frontend/containers/BasePage/BasePage.tsx
@@ -1,6 +1,5 @@
-import React, { useEffect } from "react";
+import { useEffect } from "react";
 import Head from "next/head";
-import PropTypes from "prop-types";
 import dynamic from "next/dynamic";
 
 import { initGA } from "@/utils/gtag";
@@ -11,7 +10,30 @@ import { NavItem } from "@/api/types";
 
 const WagtailUserbar = dynamic(() => import("@/components/WagtailUserbar"));
 
-const BasePage = ({ children, seo, wagtailUserbar, navigation }: { navigation: NavItem[] }) => {
+type Props = React.PropsWithChildren<{
+  navigation: NavItem[];
+  seo?: {
+    canonicalLink?: string;
+    seoHtmlTitle?: string;
+    seoMetaDescription?: string;
+    seoMetaRobots?: string;
+    seoOgDescription?: string;
+    seoOgImage?: string;
+    seoOgTitle?: string;
+    seoOgType?: string;
+    seoOgUrl?: string;
+    seoTwitterDescription?: string;
+    seoTwitterImage?: string;
+    seoTwitterTitle?: string;
+    seoTwitterUrl?: string;
+  };
+
+  wagtailUserbar?: {
+    html: string;
+  };
+}>;
+
+const BasePage = ({ children, navigation, seo = {}, wagtailUserbar }: Props) => {
   const {
     seoHtmlTitle,
     seoMetaDescription,
@@ -58,26 +80,6 @@ const BasePage = ({ children, seo, wagtailUserbar, navigation }: { navigation: N
       {!!wagtailUserbar && <WagtailUserbar {...wagtailUserbar} />}
     </>
   );
-};
-
-BasePage.defaultProps = {
-  seo: {},
-};
-
-BasePage.propTypes = {
-  children: PropTypes.node,
-  seo: PropTypes.shape({
-    seoHtmlTitle: PropTypes.string,
-    seoMetaDescription: PropTypes.string,
-    seoOgTitle: PropTypes.string,
-    seoOgDescription: PropTypes.string,
-    seoOgUrl: PropTypes.string,
-    seoTwitterTitle: PropTypes.string,
-    seoMetaRobots: PropTypes.string,
-  }),
-  wagtailUserbar: PropTypes.shape({
-    html: PropTypes.string,
-  }),
 };
 
 export default BasePage;

--- a/frontend/containers/BasePage/index.tsx
+++ b/frontend/containers/BasePage/index.tsx
@@ -1,12 +1,20 @@
-import BasePage from "./BasePage";
 import React from "react";
+import BasePage from "./BasePage";
 
-export const basePageWrap = Component => props => {
-  return (
-    <BasePage {...props} _class={Component.name}>
-      <Component {...props} />
-    </BasePage>
-  );
-};
+export function basePageWrap<P extends object>(Component: React.ComponentType<P>) {
+  const displayName = Component.displayName || Component.name || "Component";
+
+  const wrapped = function (props: P & React.ComponentProps<typeof BasePage>) {
+    return (
+      <BasePage {...props} _class={Component.name}>
+        <Component {...props} />
+      </BasePage>
+    );
+  };
+
+  wrapped.displayName = `basePageWrap(${displayName})`;
+
+  return wrapped;
+}
 
 export default BasePage;

--- a/frontend/containers/HomePage/HomePage.tsx
+++ b/frontend/containers/HomePage/HomePage.tsx
@@ -6,25 +6,17 @@ import { basePageWrap } from "../BasePage";
 
 import styles from "./HomePage.module.css";
 
-type TextAndMediaVariant = {
-  type: "text_image_block";
-} & React.ComponentProps<typeof TextAndMedia>["data"];
+import {
+  PageProps,
+  TextAndMediaVariant,
+  HeroBlockVariant,
+  TitleBlockVariant,
+  CardBlockVariant,
+} from "../types";
 
-type HeroBlockVariant = {
-  type: "hero_block";
-} & React.ComponentProps<typeof HeroBlock>["data"];
-
-type TitleBlockVariant = {
-  type: "title_block";
-} & React.ComponentProps<typeof TitleBlock>["data"];
-
-type CardBlockVariant = {
-  type: "card_block";
-} & React.ComponentProps<typeof CardBlock>["data"];
-
-export type HomePageProps = {
-  id: string;
-} & (TextAndMediaVariant | HeroBlockVariant | TitleBlockVariant | CardBlockVariant);
+type HomePageProps = PageProps<
+  TextAndMediaVariant | HeroBlockVariant | TitleBlockVariant | CardBlockVariant
+>;
 
 const HomePage = ({ content }: { content: HomePageProps[] }) => {
   return (

--- a/frontend/containers/HomePage/HomePage.tsx
+++ b/frontend/containers/HomePage/HomePage.tsx
@@ -6,13 +6,27 @@ import { basePageWrap } from "../BasePage";
 
 import styles from "./HomePage.module.css";
 
-export type HomePage = {
-  id: string;
-  type: string;
-  value: any;
-};
+type TextAndMediaVariant = {
+  type: "text_image_block";
+} & React.ComponentProps<typeof TextAndMedia>["data"];
 
-const HomePage = ({ content }: { content: HomePage[] }) => {
+type HeroBlockVariant = {
+  type: "hero_block";
+} & React.ComponentProps<typeof HeroBlock>["data"];
+
+type TitleBlockVariant = {
+  type: "title_block";
+} & React.ComponentProps<typeof TitleBlock>["data"];
+
+type CardBlockVariant = {
+  type: "card_block";
+} & React.ComponentProps<typeof CardBlock>["data"];
+
+export type HomePageProps = {
+  id: string;
+} & (TextAndMediaVariant | HeroBlockVariant | TitleBlockVariant | CardBlockVariant);
+
+const HomePage = ({ content }: { content: HomePageProps[] }) => {
   return (
     <div className={styles[""]}>
       {content?.map(contentItem => {

--- a/frontend/containers/PasswordProtectedPage/PasswordProtectedPage.tsx
+++ b/frontend/containers/PasswordProtectedPage/PasswordProtectedPage.tsx
@@ -1,90 +1,86 @@
-import React, { useState } from 'react';
-import PropTypes from 'prop-types';
-import {
-    getPasswordProtectedPage,
-    WagtailApiResponseError,
-} from '../../api/wagtail';
-import LazyContainers from '../LazyContainers';
+import React, { useState } from "react";
+import { getPasswordProtectedPage, WagtailApiResponseError } from "../../api/wagtail";
+import LazyContainers from "../LazyContainers";
 
-const PasswordProtectedPage = ({ restrictionId, pageId, csrfToken }) => {
-    const [values, setValues] = useState({ password: '' });
-    const [error, setError] = useState(null);
-    const [pageData, setPageData] = useState(null);
-
-    const handleFormChange = async (e) => {
-        e.preventDefault();
-
-        try {
-            const { json } = await getPasswordProtectedPage(
-                restrictionId,
-                pageId,
-                {
-                    ...values,
-                },
-                {
-                    headers: {
-                        'X-CSRFToken': csrfToken,
-                    },
-                }
-            );
-
-            setPageData(json);
-        } catch (e) {
-            if (!(e instanceof WagtailApiResponseError)) {
-                throw e;
-            }
-
-            switch (e.response.status) {
-                case 403:
-                    setError('Forbidden');
-                    break;
-                case 401:
-                    setError('Invalid password');
-                    break;
-                default:
-                    setError('Technical issues');
-                    break;
-            }
-        }
-    };
-
-    const handlePasswordChange = (e) => {
-        const { name, value } = e.target;
-        setValues({ ...values, [name]: value });
-    };
-
-    if (pageData) {
-        const { componentName, componentProps } = pageData;
-        const Component = LazyContainers[componentName];
-        if (!Component) {
-            return <h1>Component {componentName} not found</h1>;
-        }
-        return <Component {...componentProps} />;
-    }
-
-    return (
-        <div>
-            <h1>Password is required</h1>
-            <p>You need a password to access this website</p>
-
-            {!!error && <p>{error}</p>}
-            <p>
-                <input
-                    type="password"
-                    name="password"
-                    onChange={handlePasswordChange}
-                    placeholder="Password"
-                />
-            </p>
-            <button onClick={handleFormChange}>Continue</button>
-        </div>
-    );
+type Props = {
+  restrictionId: number;
+  pageId: number;
+  csrfToken: string;
 };
 
-PasswordProtectedPage.propTypes = {
-    restrictionId: PropTypes.number.isRequired,
-    pageId: PropTypes.number.isRequired,
-    csrfToken: PropTypes.string.isRequired,
+const PasswordProtectedPage = ({ restrictionId, pageId, csrfToken }: Props) => {
+  const [values, setValues] = useState({ password: "" });
+  const [error, setError] = useState(null);
+  const [pageData, setPageData] = useState(null);
+
+  const handleFormChange = async e => {
+    e.preventDefault();
+
+    try {
+      const { json } = await getPasswordProtectedPage(
+        restrictionId,
+        pageId,
+        {
+          ...values,
+        },
+        {
+          headers: {
+            "X-CSRFToken": csrfToken,
+          },
+        }
+      );
+
+      setPageData(json);
+    } catch (e) {
+      if (!(e instanceof WagtailApiResponseError)) {
+        throw e;
+      }
+
+      switch (e.response.status) {
+        case 403:
+          setError("Forbidden");
+          break;
+        case 401:
+          setError("Invalid password");
+          break;
+        default:
+          setError("Technical issues");
+          break;
+      }
+    }
+  };
+
+  const handlePasswordChange = e => {
+    const { name, value } = e.target;
+    setValues({ ...values, [name]: value });
+  };
+
+  if (pageData) {
+    const { componentName, componentProps } = pageData;
+    const Component = LazyContainers[componentName];
+    if (!Component) {
+      return <h1>Component {componentName} not found</h1>;
+    }
+    return <Component {...componentProps} />;
+  }
+
+  return (
+    <div>
+      <h1>Password is required</h1>
+      <p>You need a password to access this website</p>
+
+      {!!error && <p>{error}</p>}
+      <p>
+        <input
+          type="password"
+          name="password"
+          onChange={handlePasswordChange}
+          placeholder="Password"
+        />
+      </p>
+      <button onClick={handleFormChange}>Continue</button>
+    </div>
+  );
 };
 
 export default PasswordProtectedPage;

--- a/frontend/containers/PureHtmlPage/PureHtmlPage.tsx
+++ b/frontend/containers/PureHtmlPage/PureHtmlPage.tsx
@@ -1,12 +1,8 @@
-import React from 'react';
-import PropTypes from 'prop-types';
+import React from "react";
+import PropTypes from "prop-types";
 
-const PureHtmlPage = ({ html }) => (
-    <div dangerouslySetInnerHTML={{ __html: html }} />
+const PureHtmlPage = ({ html }: { html: string }) => (
+  <div dangerouslySetInnerHTML={{ __html: html }} />
 );
-
-PureHtmlPage.propTypes = {
-    html: PropTypes.string.isRequired,
-};
 
 export default PureHtmlPage;

--- a/frontend/containers/StaticPage/StaticPage.tsx
+++ b/frontend/containers/StaticPage/StaticPage.tsx
@@ -5,13 +5,11 @@ import TextAndMediaBlock from "@/components/Blocks/TextAndMediaBlock/TextAndMedi
 import styles from "./StaticPage.module.css";
 import { basePageWrap } from "@/containers/BasePage";
 
-export type StaticPage = {
-  id: string;
-  type: string;
-  value: any;
-};
+import { PageProps, TextAndMediaVariant, TitleBlockVariant, CardBlockVariant } from "../types";
 
-const StaticPage = ({ content }: { content: StaticPage[] }) => {
+type Content = PageProps<TextAndMediaVariant | TitleBlockVariant | CardBlockVariant>;
+
+const StaticPage = ({ content }: { content: Content[] }) => {
   return (
     <div className={styles[""]}>
       {content?.map(contentItem => {

--- a/frontend/containers/StorylineOverviewPage/StorylineOverviewPage.tsx
+++ b/frontend/containers/StorylineOverviewPage/StorylineOverviewPage.tsx
@@ -3,7 +3,14 @@ import StorylineOverview from "@/components/Storyline/StorylineOverview/Storylin
 import styles from "./StorylineOverviewPage.module.css";
 import { basePageWrap } from "../BasePage";
 
-const StorylineOverviewPage = ({ allInformationTypes, allRoles, allStorylines }) => {
+type Props = Pick<
+  React.ComponentProps<typeof StorylineOverview>,
+  "allInformationTypes" | "allRoles"
+> & {
+  allStorylines: React.ComponentProps<typeof StorylineOverview>["storylines"];
+};
+
+const StorylineOverviewPage = ({ allInformationTypes, allRoles, allStorylines }: Props) => {
   return (
     <div className={styles["StorylineOverviewPage"]}>
       <StorylineOverview

--- a/frontend/containers/StorylinePage/StorylinePage.tsx
+++ b/frontend/containers/StorylinePage/StorylinePage.tsx
@@ -5,12 +5,9 @@ import TextAndMediaBlock from "@/components/Blocks/TextAndMediaBlock/TextAndMedi
 import styles from "./StorylinePage.module.css";
 import React from "react";
 
-export type Storyline = {
-  id: string;
-  type: string;
-  // eslint-disable-next-line
-  value: any;
-};
+import { PageProps, SectionVariant, TextAndMediaVariant } from "../types";
+
+type Storyline = PageProps<SectionVariant | TextAndMediaVariant>;
 
 export type Scenario = {
   id: string;

--- a/frontend/containers/WikiPage/WikiPage.test.tsx
+++ b/frontend/containers/WikiPage/WikiPage.test.tsx
@@ -1,4 +1,4 @@
-import { render } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import WikiPage from "./";
 // import data from './WikiPage.data';
 
@@ -8,13 +8,19 @@ jest.mock("next/router", () => ({
   }),
 }));
 
-describe("<WikiPage />", () => {
-  it("Renders an empty WikiPage", () => {
-    render(<WikiPage />);
-  });
+describe("WikiPage with simple text", () => {
+  it("renders the content", () => {
+    render(
+      <WikiPage
+        richText="Hello world"
+        wikiMenu={{
+          items: [{ relativeUrl: "/test/", title: "Test page", children: [] }],
+          meta: { totalCount: 1 },
+        }}
+      />
+    );
 
-  // it('Renders WikiPage with data', () => {
-  //     const { container } = render(<WikiPage {...data} />);
-  //     expect(container).toMatchSnapshot();
-  // });
+    expect(screen.getByText("Test page")).toBeInTheDocument();
+    expect(screen.getByText("Hello world")).toBeInTheDocument();
+  });
 });

--- a/frontend/containers/WikiPage/WikiPage.tsx
+++ b/frontend/containers/WikiPage/WikiPage.tsx
@@ -78,7 +78,7 @@ const WikiPage = ({ richText, wikiMenu }: WikiContainerProps) => {
 
         <main className="flex flex-1 flex-col">
           <div className="border-b-2 border-gray-200 py-3 pl-10">
-            {pages && <Breadcrumbs path={path} posts={pages} />}
+            {pages && <Breadcrumbs path={path ? [path].flat() : []} posts={pages} />}
           </div>
           <div className="p-3 flex flex-1 flex-row justify-between">
             <Article article={richText}></Article>

--- a/frontend/containers/WikiPage/WikiPage.tsx
+++ b/frontend/containers/WikiPage/WikiPage.tsx
@@ -33,7 +33,7 @@ const WikiPage = ({ richText, wikiMenu }: WikiContainerProps) => {
     const prefixmap = new Map();
     for (const url of urls) {
       url.children = []; // extend node with the array
-      const lastChar = url.relativeUrl.substr(-1);
+      const lastChar = url.relativeUrl.slice(-1);
       let address = url.relativeUrl;
       if (lastChar === "/") {
         address = url.relativeUrl.slice(0, -1);

--- a/frontend/containers/WikiPage/WikiPage.tsx
+++ b/frontend/containers/WikiPage/WikiPage.tsx
@@ -24,7 +24,7 @@ const WikiPage = ({ richText, wikiMenu }: WikiContainerProps) => {
   const router = useRouter();
   const { path } = router.query;
 
-  const [wikiPostsHierarchy, setWikiPostsHierarchy] = useState<any[]>([]);
+  const [wikiPostsHierarchy, setWikiPostsHierarchy] = useState<WikiPageProps[]>([]);
   const [pages, setPages] = useState<WikiPageProps[]>([]);
 
   const createWikiPostsHierarchy = (items: Array<WikiPageProps>) => {

--- a/frontend/containers/WikiPage/WikiPage.tsx
+++ b/frontend/containers/WikiPage/WikiPage.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from "react";
+import Link from "next/link";
 import { useRouter } from "next/router";
 import { basePageWrap } from "../BasePage";
 import Aside from "@/components/Wiki/Aside";
@@ -62,11 +63,12 @@ const WikiPage = ({ richText, wikiMenu }: WikiContainerProps) => {
     <div className="flex min-h-screen min-w-full flex-col">
       <header className="flex h-[8vh] flex-row justify-start overflow-hidden bg-holon-blue-900 align-middle">
         <div className="flex w-3/12 justify-center justify-items-center">
-          <a href="/" className="flex flex-row">
-            Icon
-            {/* <BookOpenIcon className="h-10 w-10 self-center text-white" /> */}
-            <h1 className="ml-2 self-center py-2 text-3xl font-bold text-white">Holon Wiki</h1>
-          </a>
+          <Link href="/">
+            <a className="flex flex-row">
+              Icon
+              <h1 className="ml-2 self-center py-2 text-3xl font-bold text-white">Holon Wiki</h1>
+            </a>
+          </Link>
         </div>
       </header>
       <div className="flex w-full flex-1 flex-row">

--- a/frontend/containers/types.ts
+++ b/frontend/containers/types.ts
@@ -1,0 +1,29 @@
+import CardBlock from "@/components/Blocks/CardsBlock";
+import HeroBlock from "@/components/Blocks/HeroBlock";
+import TitleBlock from "@/components/Blocks/TitleBlock";
+import Section from "@/components/Section/Section";
+import TextAndMedia from "@/components/TextAndMedia";
+
+export type CardBlockVariant = {
+  type: "card_block";
+} & React.ComponentProps<typeof CardBlock>["data"];
+
+export type HeroBlockVariant = {
+  type: "hero_block";
+} & React.ComponentProps<typeof HeroBlock>["data"];
+
+export type SectionVariant = {
+  type: "section";
+} & React.ComponentProps<typeof Section>["data"];
+
+export type TextAndMediaVariant = {
+  type: "text_image_block";
+} & React.ComponentProps<typeof TextAndMedia>["data"];
+
+export type TitleBlockVariant = {
+  type: "title_block";
+} & React.ComponentProps<typeof TitleBlock>["data"];
+
+export type PageProps<Types> = {
+  id: string;
+} & Types;


### PR DESCRIPTION
This PR is to partially complete #122. It removes the use of PropTypes throughout the components we got from Pipit. It also adds tests for some of these Pipit components, and others we've added recently.

I don't consider it to completely satisfy #122 since there are still many other recently-added components which are not tested, but I feel it's better to deal with this debt as we move forwards rather than in one huge pull request where it becomes increasingly difficult to handle the merge conflicts.

Feedback is very welcome.

*(I'm unsure who to assign this to for review; please reassign as you see fit).*

Closes #122.