### PR TITLE
fixes bug alt text

### DIFF
--- a/frontend/components/MediaContent/MediaContent.tsx
+++ b/frontend/components/MediaContent/MediaContent.tsx
@@ -13,7 +13,6 @@ type MediaDetails = {
         type: "video";
         id: string;
         value: string;
-        altText: string;
       }
     | {
         type: "image";
@@ -33,8 +32,7 @@ type MediaDetails = {
 
 export default function MediaContent({ media, alt }: Props) {
   const [hasWindow, setHasWindow] = useState(false);
-
-  const altText2 = alt === "" ? media[0].value.img.alt : alt;
+  const altText = alt;
 
   // UseEffect used for Hydration Error fix. Keep it
   useEffect(() => {
@@ -64,7 +62,7 @@ export default function MediaContent({ media, alt }: Props) {
         return mediaDetail.value ? (
           <Image
             src={mediaDetail.value.img.src}
-            alt={altText2}
+            alt={altText === "" ? mediaDetail.value.img.alt : altText}
             className="image"
             width="1600"
             height="900"

--- a/frontend/components/MediaContent/MediaContent.tsx
+++ b/frontend/components/MediaContent/MediaContent.tsx
@@ -32,7 +32,6 @@ type MediaDetails = {
 
 export default function MediaContent({ media, alt }: Props) {
   const [hasWindow, setHasWindow] = useState(false);
-  const altText = alt;
 
   // UseEffect used for Hydration Error fix. Keep it
   useEffect(() => {
@@ -62,7 +61,7 @@ export default function MediaContent({ media, alt }: Props) {
         return mediaDetail.value ? (
           <Image
             src={mediaDetail.value.img.src}
-            alt={altText === "" ? mediaDetail.value.img.alt : altText}
+            alt={alt}
             className="image"
             width="1600"
             height="900"
@@ -70,9 +69,9 @@ export default function MediaContent({ media, alt }: Props) {
         ) : (
           ""
         );
+      default:
+        return null;
     }
-
-    return null;
   }
 
   // for now it is only possible to show one mediaitem (image or video).


### PR DESCRIPTION
If no alt text was added to a video in a text-media block there was an error. This is fixed by only determining the alt text when an image is uploaded. 