### PR TITLE
Bugfix Storyline page. Fix when Thumbnail is empty

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -11,7 +11,7 @@
             "program": "${workspaceFolder}/src/manage.py",
             "args": [
                 "runserver",
-                "0.0.0.0:8001",
+                "0.0.0.0:8000",
                 "--noreload",
                 "--nothreading"
             ],

--- a/src/main/pages/storyline.py
+++ b/src/main/pages/storyline.py
@@ -91,7 +91,9 @@ class StorylinePage(HeadlessPreviewMixin, BasePage):
 
     @property
     def thumbnail_rendition_url(self):
-        url = self.thumbnail.get_rendition("fill-750x380|jpegquality-80")
+        url = None
+        if self.thumbnail is not None:
+            url = self.thumbnail.get_rendition("fill-750x380|jpegquality-80")
         return url
 
     description = models.TextField(null=True, blank=True, help_text="Description of the storyline")

--- a/src/main/pages/storylineoverview_serializer.py
+++ b/src/main/pages/storylineoverview_serializer.py
@@ -26,18 +26,11 @@ class StorylineOverviewPageSerializer(BasePageSerializer):
                 it_dict = {"name": it.name, "icon": it.icon}
                 it_array.append(it_dict)
 
-            thumbnail = {
-                "url": "",
-                "width": 1,
-                "height": 1,
-            }
-
-            if sl.thumbnail_rendition_url is not None:
-                thumbnail = {
-                    "url": sl.thumbnail_rendition_url.url,
-                    "width": sl.thumbnail_rendition_url.width,
-                    "height": sl.thumbnail_rendition_url.height,
-                }
+            thumbnail = (
+                {"url": sl.thumbnail_rendition_url.url}
+                if sl.thumbnail_rendition_url is not None
+                else None
+            )
 
             sl_dict = {
                 "title": sl.title,

--- a/src/main/pages/storylineoverview_serializer.py
+++ b/src/main/pages/storylineoverview_serializer.py
@@ -26,6 +26,19 @@ class StorylineOverviewPageSerializer(BasePageSerializer):
                 it_dict = {"name": it.name, "icon": it.icon}
                 it_array.append(it_dict)
 
+            thumbnail = {
+                "url": "",
+                "width": 1,
+                "height": 1,
+            }
+
+            if sl.thumbnail_rendition_url is not None:
+                thumbnail = {
+                    "url": sl.thumbnail_rendition_url.url,
+                    "width": sl.thumbnail_rendition_url.width,
+                    "height": sl.thumbnail_rendition_url.height,
+                }
+
             sl_dict = {
                 "title": sl.title,
                 "description": sl.description,
@@ -33,11 +46,7 @@ class StorylineOverviewPageSerializer(BasePageSerializer):
                 "slug": sl.slug,
                 "roles": roles_array,
                 "information_types": it_array,
-                "thumbnail": {
-                    "url": sl.thumbnail_rendition_url.url,
-                    "width": sl.thumbnail_rendition_url.width,
-                    "height": sl.thumbnail_rendition_url.height,
-                },
+                "thumbnail": thumbnail,
             }
 
             return_all_storylines.append(sl_dict)


### PR DESCRIPTION
Error ontstond op de Storylinepage omdat deze Storylines inlaad, die (niet allemaal) een Thumbnail hadden. Daarop werd in de backend niet afgevangen dat dit eventueel leeg kon zijn.