### PR TITLE
Updated Wagtail version from 4.0 to 4.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,0 @@
-{
-  "name": "workspace",
-  "lockfileVersion": 2,
-  "requires": true,
-  "packages": {}
-}

--- a/src/requirements/base.txt
+++ b/src/requirements/base.txt
@@ -4,7 +4,7 @@ django-storages==1.13
 psycopg2==2.9.3
 sentry_sdk==1.9
 python-dotenv==0.21
-wagtail>=4.0,<4.1
+wagtail>=4.1,<4.2
 wagtail-meta-preview
 wagtail_headless_preview==0.4
 django-cors-headers==3.13


### PR DESCRIPTION
Updates Wagtail from 4.0 to 4.1

Steps to install on local/server:
- pip install -r /src/requirements/base.txt
- python /src/manage.py migrate
