### PR TITLE
Minor changes to the ETM upscaling module

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -37,6 +37,5 @@
     },
     "[typescriptreact]": {
         "editor.defaultFormatter": "esbenp.prettier-vscode"
-    },
-    "peacock.color": "#dd0531"
+    }
 }

--- a/src/holon/models/pepe.py
+++ b/src/holon/models/pepe.py
@@ -593,9 +593,7 @@ class PostProcessor:
                 "netload": round(self.etm_results["national_kpi_network_load"], 1),
                 "costs": round(self.etm_results["national_total_costs"], -8),  # reduce significance
                 # ETM returns factor instead of percentage for sustainability
-                "sustainability": round(
-                    100 * self.etm_results["national_share_of_renewable_electricity"], 1
-                ),
+                "sustainability": round(100 * self.etm_results["national_renewability"], 1),
                 "self_sufficiency": round(self.etm_results["national_kpi_self_sufficiency"], 1),
             },
             "local": {

--- a/src/holon/services/etm_kpis.config.yml
+++ b/src/holon/services/etm_kpis.config.yml
@@ -4,11 +4,11 @@ national_total_costs:
     data: value
     etm_key: total_costs
 
-national_share_of_renewable_electricity:
+national_renewability:
   value:
     type: query
     data: value
-    etm_key: dashboard_share_of_renewable_electricity
+    etm_key: dashboard_renewability
 
 national_kpi_network_load:
   value:

--- a/src/holon/services/etm_kpis.config.yml
+++ b/src/holon/services/etm_kpis.config.yml
@@ -14,7 +14,7 @@ national_kpi_network_load:
   value:
     type: query
     data: value
-    etm_key: kpi_required_additional_mv_network_percentage
+    etm_key: kpi_required_additional_hv_network_percentage
 
 national_kpi_self_sufficiency:
   value:

--- a/src/holon/services/etm_kpis.config.yml
+++ b/src/holon/services/etm_kpis.config.yml
@@ -14,7 +14,7 @@ national_kpi_network_load:
   value:
     type: query
     data: value
-    etm_key: kpi_required_additional_hv_network_percentage
+    etm_key: kpi_required_additional_mv_network_percentage
 
 national_kpi_self_sufficiency:
   value:

--- a/src/holon/views.py
+++ b/src/holon/views.py
@@ -29,7 +29,7 @@ class HolonService(generics.CreateAPIView):
             # TODO: this is hardcoded; should be a result from the DB::scenario linked to the storyline
             # NOTE: other things (like balancer in ETM_service) are now also hardcoded to work with
             # this specific scenario, please notify @noracto when you change this. Scenario = KEV
-            data["scenario"] = {"etm_scenario_id": 2171098, "model_name": "technical_debt"}
+            data["scenario"] = {"etm_scenario_id": 2175158, "model_name": "technical_debt"}
             pepe.preprocessor = data
 
             # holon_results = {}


### PR DESCRIPTION
- [x] Update the national renewability to `dashboard_renewability`
- [x] Incorporate a more reasonable value for the `wtp_of_energy_flexibility_mv_batteries_electricity` such that they actually contribute to reducing net congestion in some way (perhaps as a default value in the base scenario?)
~~- [x] Should we synchronize `kpi_required_additional_hv_network_percentage` and `capacity_of_energy_flexibility_mv_batteries_electricity` such that they are both at the same net level?~~

Reverted the last point due to the fact that electric trucks hook in to the grid at the HV level (cc @marliekeverweij, right?)