### PR TITLE
235 button element should have a word based line break now it breaks halfway a word

### DIFF
--- a/frontend/components/Blocks/ParagraphBlock/ParagraphBlock.tsx
+++ b/frontend/components/Blocks/ParagraphBlock/ParagraphBlock.tsx
@@ -36,6 +36,9 @@ export default function Paragraph({ data }: Props) {
           <div
             className={`flex flex-col relative defaultBlockPadding ${gridValue.left} ${backgroundLeftColor}`}
             data-testid="paragraph">
+            {data.value.background.size !== "bg_full" && (
+              <span className={`extra_bg ${backgroundLeftColor}`}></span>
+            )}
             <RawHtml html={data.value?.text} />
           </div>
         </div>

--- a/frontend/components/Card/Card.tsx
+++ b/frontend/components/Card/Card.tsx
@@ -12,10 +12,10 @@ const CardTitle = ({ condition, children, ...linkProps }: CardTitleProps) => {
       <StretchedLink
         {...linkProps}
         content={children}
-        className={`block font-bold line-clamp-2 break-all`}></StretchedLink>
+        className={`block font-bold line-clamp-2`}></StretchedLink>
     );
   }
-  return <strong className="block line-clamp-2 break-all">{children}</strong>;
+  return <strong className="block line-clamp-2">{children}</strong>;
 };
 
 export default function Card({ cardItem, cardType }: CardProps) {
@@ -44,14 +44,14 @@ export default function Card({ cardItem, cardType }: CardProps) {
         card: "flex-row min-w-96 hover:drop-shadow-md h-16 md:h-24",
         imgSpan: "w-1/3",
         img: "rounded-l-lg group-hover:brightness-110",
-        text: "flex-row justify-between items-center w-2/3 ml-12 text-xl md:text-2xl",
+        text: "flex-row justify-between items-center w-2/3 ml-6 md:ml-12 text-xl md:text-2xl m-2 md:m-4",
       });
     } else {
       return (cardStyling = {
         card: "flex-col  min-h-96  mb-4 h-[360px] xl:h-[400px] overflow-hidden",
         imgSpan: "h-2/3",
         img: "rounded-t-lg duration-300 ease-in group-hover:brightness-100 group-hover:scale-110",
-        text: "flex-col h-1/3",
+        text: "flex-col h-1/3 m-4",
       });
     }
   }
@@ -101,7 +101,7 @@ export default function Card({ cardItem, cardType }: CardProps) {
           )}
         </span>
 
-        <span className={`flex gap-2 overflow-hidden m-4 ${cardStyling.text}`}>
+        <span className={`flex gap-2 overflow-hidden ${cardStyling.text}`}>
           <CardTitle
             condition={cardItem.slug || cardItem.itemLink?.length > 0}
             href={createLink(cardItem)}


### PR DESCRIPTION
this pull request solves issue 235. 
- line-break is now word based. 

In addition I added a few lines to the paragraph block to ensure that the background color is outlined all the way to the left (it wasn't added to my commit in branch #179 which is already merged). 