### PR TITLE
Expand cost module

### DIFF
--- a/src/holon/economic/im_sorry.py
+++ b/src/holon/economic/im_sorry.py
@@ -5,10 +5,13 @@ import numpy as np
 # in the etm_costs.config.yml
 ETM_MAPPING = {
     "depreciation_costs_buildings_solar_panels_per_kw": ("BUILDING", "PHOTOVOLTAIC"),
+    "depreciation_costs_households_solar_panels_per_kw": ("HOUSE", "PHOTOVOLTAIC"),
     "depreciation_costs_solar_farm_per_kw": ("SOLARFARM", "PHOTOVOLTAIC"),
+    "depreciation_costs_wind_farm_inland_per_kw": ("WINDFARM", "INLAND_WIND_TURBINE"),
     "depreciation_costs_buildings_gas_burner_per_kw": ("BUILDING", "GAS_BURNER"),
     "depreciation_costs_industry_solar_panels_per_kw": ("INDUSTRY", "PHOTOVOLTAIC"),
     "depreciation_costs_industry_gas_burner_per_kw": ("INDUSTRY", "GAS_BURNER"),
+
     "hourly_price_of_electricity_per_mwh": ("SystemHourlyElectricity", ""),  # TODO: check this key
     "price_of_natural_gas_per_mwh": ("totalMethane", ""),
     "price_of_hydrogen_per_mwh": ("totalHydrogen", ""),

--- a/src/holon/economic/im_sorry.py
+++ b/src/holon/economic/im_sorry.py
@@ -11,6 +11,7 @@ ETM_MAPPING = {
     "depreciation_costs_buildings_gas_burner_per_kw": ("BUILDING", "GAS_BURNER"),
     "depreciation_costs_industry_solar_panels_per_kw": ("INDUSTRY", "PHOTOVOLTAIC"),
     "depreciation_costs_industry_gas_burner_per_kw": ("INDUSTRY", "GAS_BURNER"),
+    "depreciation_costs_industry_electrolyser_per_kw": ("INDUSTRY", "ELECTROLYSER"),
 
     "hourly_price_of_electricity_per_mwh": ("SystemHourlyElectricity", ""),  # TODO: check this key
     "price_of_natural_gas_per_mwh": ("totalMethane", ""),

--- a/src/holon/services/etm_costs.config.yml
+++ b/src/holon/services/etm_costs.config.yml
@@ -54,6 +54,18 @@ depreciation_costs_buildings_solar_panels_per_kw:
     data: value
     etm_key: depreciation_costs_buildings_solar_panels_per_kw
 
+depreciation_costs_households_solar_panels_per_kw:
+  value:
+    type: query
+    data: value
+    etm_key: depreciation_costs_households_solar_panels_per_kw
+
+depreciation_costs_wind_farm_inland_per_kw:
+  value:
+    type: query
+    data: value
+    etm_key: depreciation_costs_wind_farm_inland_per_kw
+
 depreciation_costs_industry_solar_panels_per_kw:
   value:
     type: query

--- a/src/holon/services/etm_costs.config.yml
+++ b/src/holon/services/etm_costs.config.yml
@@ -30,6 +30,12 @@ depreciation_costs_grid_battery_per_mwh:
     data: value
     etm_key: depreciation_costs_grid_battery_per_mwh
 
+depreciation_costs_industry_electrolyser_per_kw:
+  value:
+    type: query
+    data: value
+    etm_key: depreciation_costs_industry_electrolyser_per_kw
+
 depreciation_costs_solar_farm_per_kw:
   value:
     type: query


### PR DESCRIPTION
This branch adds costs module elements for the two cases "Buurtelektrificatie" and "Energy Hub". It is work in progress, as more elements may have to be added.

So far, added to the costs module are:

- Inland wind turbines
- Household solar PV panels
- Industry electrolyser