### PR TITLE
340 styling en opschonen inlog flow

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,3 +1,3 @@
 WAGTAIL_API_URL=http://localhost:8000/wt/api/nextjs
 NEXT_PUBLIC_WAGTAIL_API_URL=http://localhost:8000/wt/api/nextjs
-NEXT_PUBLIC_BASE_URL=http://localhost:8000
+NEXT_PUBLIC_BASE_URL=http://localhost:8000/wt

--- a/frontend/api/auth.ts
+++ b/frontend/api/auth.ts
@@ -1,0 +1,82 @@
+import * as Cookies from "es-cookie";
+import TokenService from "@/services/token";
+
+const API_URL = process.env.NEXT_PUBLIC_BASE_URL || "/wt";
+
+export async function registerUser(userData) {
+  TokenService.setCSRFToken();
+
+  const response = await fetch(`${API_URL}/dj-rest-auth/registration/`, {
+    method: "POST",
+    body: JSON.stringify({
+      username: userData.username,
+      password1: userData.password,
+      password2: userData.verifyPassword,
+      email: userData.email,
+    }),
+    headers: {
+      "Content-Type": "application/json",
+      "X-CSRFToken": Cookies.get("csrftoken"),
+    },
+    credentials: "include",
+  });
+
+  return response;
+}
+
+export async function logIn(userData) {
+  return await fetch(`${API_URL}/api/token/`, {
+    method: "POST",
+    body: JSON.stringify({
+      username: userData.username,
+      password: userData.password,
+    }),
+    headers: {
+      "Content-Type": "application/json",
+    },
+    credentials: "include",
+  });
+}
+
+export async function updateProfile(userData) {
+  const response = await fetch(`${API_URL}/dj-rest-auth/user/`, {
+    method: "PATCH",
+    body: JSON.stringify({
+      first_name: userData.first_name,
+      last_name: userData.last_name,
+      email: userData.email,
+      currentPassword: userData.currentPassword,
+      newPassword: userData.password,
+      verifyNewPassword: userData.verifyPassword,
+    }),
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: "Bearer " + TokenService.getAccessToken(),
+    },
+    credentials: "include",
+  });
+  return response;
+}
+
+export async function updatePassword(userData) {
+  const response = await fetch(`${API_URL}/dj-rest-auth/password/change/`, {
+    method: "POST",
+    body: JSON.stringify({
+      old_password: userData.currentPassword,
+      new_password1: userData.password,
+      new_password2: userData.verifyPassword,
+    }),
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: "Bearer " + TokenService.getAccessToken(),
+    },
+    credentials: "include",
+  });
+  return response;
+}
+
+/*deze functie wordt later toegevoegd
+  function handleRemoveProfile(e) {
+    console.log("profiel verwijderd");
+  }
+  */

--- a/frontend/components/Header/Header.tsx
+++ b/frontend/components/Header/Header.tsx
@@ -8,7 +8,7 @@ export default function Header({ navigation }: { navigation: NavItem[] }) {
   const [menuOpen, setMenuOpen] = useState(false);
   const [loggedIn, setLoggedIn] = useState(false);
   const { user, mutateUser } = useUser({});
-  const nameUser = user ? user.username : "";
+  const nameUser = user ? (user.first_name ? user.first_name : user.username) : "";
 
   useEffect(() => {
     if (user && user.username) {

--- a/frontend/components/Header/Navbar.tsx
+++ b/frontend/components/Header/Navbar.tsx
@@ -56,8 +56,16 @@ export default function Navbar({
       })}
 
       {loggedIn && nameUser ? (
-        <li className="px-2 py-3 md:py-2 text-xl text-holon-blue-900 dark:text-white sm:p-0">
-          {nameUser}
+        <li>
+          <Link href="/profiel">
+            <a
+              className={`w-full cursor-pointer px-2 py-3 md:py-2 text-xl text-holon-blue-900 dark:text-white hover:underline hover:decoration-gray-300 hover:decoration-2 hover:underline-offset-4 sm:p-0 ${
+                router.asPath === `/profiel` &&
+                "underline decoration-holon-blue-900 decoration-2 underline-offset-4"
+              }`}>
+              {nameUser}
+            </a>
+          </Link>
         </li>
       ) : (
         ""

--- a/frontend/components/Login/LoginForm.tsx
+++ b/frontend/components/Login/LoginForm.tsx
@@ -2,8 +2,7 @@ import { useState } from "react";
 import Link from "next/link";
 import TokenService from "@/services/token";
 import useUser from "@/utils/useUser";
-
-const API_URL = process.env.NEXT_PUBLIC_BASE_URL || "/wt";
+import { logIn } from "@/api/auth";
 
 export default function LoginForm() {
   const [userData, setUserData] = useState({ username: "", password: "" });
@@ -24,17 +23,7 @@ export default function LoginForm() {
     e.preventDefault();
 
     mutateUser(
-      await fetch(`${API_URL}/api/token/`, {
-        method: "POST",
-        body: JSON.stringify({
-          username: userData.username,
-          password: userData.password,
-        }),
-        headers: {
-          "Content-Type": "application/json",
-        },
-        credentials: "include",
-      })
+      logIn(userData)
         .then(res => {
           if (res.status == 401) {
             setErrorMessage("Uw gebruikersnaam/wachtwoord is niet correct");

--- a/frontend/components/Login/LoginForm.tsx
+++ b/frontend/components/Login/LoginForm.tsx
@@ -9,7 +9,7 @@ export default function LoginForm() {
   const [userData, setUserData] = useState({ username: "", password: "" });
   const [showErrorMessage, setShowErrorMessage] = useState(false);
   const [errorMessage, setErrorMessage] = useState("Er is iets fout gegaan met het inloggen.");
-  const { mutateUser } = useUser({ redirectTo: "/profiel", redirectIfFound: true });
+  const { mutateUser } = useUser({ redirectTo: "/", redirectIfFound: true });
 
   function handleInputChange(e: React.ChangeEvent<HTMLInputElement>): void {
     e.preventDefault();

--- a/frontend/components/Login/LoginForm.tsx
+++ b/frontend/components/Login/LoginForm.tsx
@@ -2,7 +2,7 @@ import { useState } from "react";
 import Link from "next/link";
 import TokenService from "@/services/token";
 import useUser from "@/utils/useUser";
-import { logIn } from "@/api/auth";
+import { logIn } from "../../api/auth";
 
 export default function LoginForm() {
   const [userData, setUserData] = useState({ username: "", password: "" });

--- a/frontend/components/Registration/RegistrationForm.tsx
+++ b/frontend/components/Registration/RegistrationForm.tsx
@@ -2,7 +2,7 @@ import React, { useState } from "react";
 import PasswordInput from "../PasswordInput/PasswordInput";
 import SuccessModal from "./SuccessModal";
 import useUser from "@/utils/useUser";
-import { registerUser } from "@/api/auth";
+import { registerUser } from "../../api/auth";
 
 export default function RegistrationForm() {
   const [userData, setUserData] = useState({

--- a/frontend/components/Registration/RegistrationForm.tsx
+++ b/frontend/components/Registration/RegistrationForm.tsx
@@ -1,11 +1,8 @@
 import React, { useState } from "react";
-import * as Cookies from "es-cookie";
 import PasswordInput from "../PasswordInput/PasswordInput";
 import SuccessModal from "./SuccessModal";
-import TokenService from "@/services/token";
 import useUser from "@/utils/useUser";
-
-const API_URL = process.env.NEXT_PUBLIC_BASE_URL || "/wt";
+import { registerUser } from "@/api/auth";
 
 export default function RegistrationForm() {
   const [userData, setUserData] = useState({
@@ -43,30 +40,15 @@ export default function RegistrationForm() {
 
   async function handleSubmit(e) {
     e.preventDefault();
-    TokenService.setCSRFToken();
 
-    const response = await fetch(`${API_URL}/dj-rest-auth/registration/`, {
-      method: "POST",
-      body: JSON.stringify({
-        username: userData.username,
-        password1: userData.password,
-        password2: userData.verifyPassword,
-        email: userData.email,
-      }),
-      headers: {
-        "Content-Type": "application/json",
-        "X-CSRFToken": Cookies.get("csrftoken"),
-      },
-      credentials: "include",
+    registerUser(userData).then(res => {
+      if (res.ok) {
+        setShowSuccessModal(true);
+        setUserData({ username: "", email: "", password: "", verifyPassword: "" });
+      } else {
+        setErrorMessage("Er is iets fout gegaan met je registratie.");
+      }
     });
-
-    const message = await response;
-    if (message.ok) {
-      setShowSuccessModal(true);
-      setUserData({ username: "", email: "", password: "", verifyPassword: "" });
-    } else {
-      setErrorMessage("Er is iets fout gegaan met je registratie.");
-    }
   }
 
   return (

--- a/frontend/components/Registration/SuccessModal.tsx
+++ b/frontend/components/Registration/SuccessModal.tsx
@@ -9,7 +9,7 @@ export default function SuccessModal({ onClose }) {
 
   return (
     <div>
-      <div className="z-10 overflow-y-auto bg-gray-100 w-3/4 md:w-2/3 lg:w-1/3 h-[300px] absolute top-[15%] left-1/2 translate-x-[-50%] border-2 border-gray-700 border-solid rounded">
+      <div className="z-10 overflow-y-auto bg-gray-100 w-3/4 md:w-2/3 lg:w-1/3 h-[300px] absolute  left-1/2 translate-x-[-50%] border-2 border-gray-700 border-solid rounded">
         <div className="flex flow-row justify-end m-4  sm:p-0">
           <button type="button" className="text-gray-800" onClick={handleCloseClick}>
             X

--- a/frontend/components/UserProfile/UpdatePassword.tsx
+++ b/frontend/components/UserProfile/UpdatePassword.tsx
@@ -5,9 +5,19 @@ type Props = {
   handleSubmit: React.FormEventHandler<HTMLFormElement>;
   input: object;
   setMessage: React.Dispatch<React.SetStateAction<string>>;
+  message: {
+    color: string;
+    message: string;
+  };
 };
 
-export default function UpdatePassword({ handleChange, handleSubmit, input, setMessage }: Props) {
+export default function UpdatePassword({
+  handleChange,
+  handleSubmit,
+  input,
+  setMessage,
+  message,
+}: Props) {
   const onInputChange = (e: React.ChangeEvent<HTMLInputElement>): void => {
     e.preventDefault();
     handleChange({ ...input, [e.target.name]: e.target.value });
@@ -34,10 +44,13 @@ export default function UpdatePassword({ handleChange, handleSubmit, input, setM
 
         <PasswordInput inputChange={handleChange} input={input} setParentMessage={setMessage} />
 
-        <div className="flex justify-end">
-          <button type="submit" className="buttonDark mt-8">
-            Wachtwoord updaten
-          </button>
+        <div className="flex flex-col">
+          <p className={`${message.color} mt-2`}>{message.message}</p>
+          <div className="flex justify-end">
+            <button type="submit" className="buttonDark mt-6">
+              Wachtwoord updaten
+            </button>
+          </div>
         </div>
       </form>
     </div>

--- a/frontend/components/UserProfile/UserProfile.tsx
+++ b/frontend/components/UserProfile/UserProfile.tsx
@@ -1,11 +1,9 @@
 import React, { useState, useEffect } from "react";
 import UpdatePassword from "./UpdatePassword";
 import useUser from "@/utils/useUser";
-import TokenService from "@/services/token";
+import { updateProfile, updatePassword } from "@/api/auth";
 
-const API_URL = process.env.NEXT_PUBLIC_BASE_URL || "/wt";
-
-type UserData = {
+export type UserData = {
   first_name: string;
   last_name: string;
   currentPassword: string;
@@ -52,30 +50,14 @@ export default function UserProfile() {
 
   async function handleUpdateProfile(e: React.SyntheticEvent<HTMLInputElement, SubmitEvent>) {
     e.preventDefault();
-    const response = await fetch(`${API_URL}/dj-rest-auth/user/`, {
-      method: "PATCH",
-      body: JSON.stringify({
-        first_name: userData.first_name,
-        last_name: userData.last_name,
-        email: userData.email,
-        currentPassword: userData.currentPassword,
-        newPassword: userData.password,
-        verifyNewPassword: userData.verifyPassword,
-      }),
-      headers: {
-        "Content-Type": "application/json",
-        Authorization: "Bearer " + TokenService.getAccessToken(),
-      },
-      credentials: "include",
+    updateProfile(userData).then(res => {
+      if (res.ok) {
+        setMessageProfileUpdate("Je profiel is succesvol geupdate");
+        setIsDisabled(true);
+      } else {
+        setMessageProfileUpdate("Er is iets mis gegaan met het updaten van je profiel");
+      }
     });
-
-    const message = await response;
-    if (message.ok) {
-      setMessageProfileUpdate("Je profiel is succesvol geupdate");
-      setIsDisabled(true);
-    } else {
-      setMessageProfileUpdate("Er is iets mis gegaan met het updaten van je profiel");
-    }
   }
 
   function handlePasswordChange(input: UserData) {
@@ -86,52 +68,37 @@ export default function UserProfile() {
   async function handleUpdatePassword(e: React.SyntheticEvent<HTMLInputElement, SubmitEvent>) {
     e.preventDefault();
 
-    const response = await fetch(`${API_URL}/dj-rest-auth/password/change/`, {
-      method: "POST",
-      body: JSON.stringify({
-        old_password: userData.currentPassword,
-        new_password1: userData.password,
-        new_password2: userData.verifyPassword,
-      }),
-      headers: {
-        "Content-Type": "application/json",
-        Authorization: "Bearer " + TokenService.getAccessToken(),
-      },
-      credentials: "include",
-    });
-    const res = await response;
-    const message = await response.json();
-
-    if (message.old_password) {
-      if (message.old_password[0].includes("incorrectly")) {
+    updatePassword(userData).then(res => {
+      if (res.ok) {
         setMessagePasswordUpdate({
           ...messagePasswordUpdate,
-          message:
-            "Je huidige wachtwoord is niet correct. Hierdoor kunnen wij helaas geen nieuw wachtwoord aanmaken.",
-          color: "text-holon-red",
+          message: "Je nieuwe wachtwoord is succesvol aangemaakt.",
+          color: "text-holon-blue-900",
+        });
+        setUserData({ ...userData, currentPassword: "", password: "", verifyPassword: "" });
+      } else {
+        res.json().then(message => {
+          console.log(message);
+          if (message.old_password) {
+            if (message.old_password[0].includes("incorrectly")) {
+              setMessagePasswordUpdate({
+                ...messagePasswordUpdate,
+                message:
+                  "Je huidige wachtwoord is niet correct. Hierdoor kunnen wij helaas geen nieuw wachtwoord aanmaken.",
+                color: "text-holon-red",
+              });
+            }
+          } else {
+            setMessagePasswordUpdate({
+              ...messagePasswordUpdate,
+              message: "Er is iets mis gegaan met het updaten van je wachtwoord",
+              color: "text-holon-red",
+            });
+          }
         });
       }
-    } else if (res.ok) {
-      setMessagePasswordUpdate({
-        ...messagePasswordUpdate,
-        message: "Je nieuwe wachtwoord is succesvol aangemaakt.",
-        color: "text-holon-blue-900",
-      });
-      setUserData({ ...userData, currentPassword: "", password: "", verifyPassword: "" });
-    } else {
-      setMessagePasswordUpdate({
-        ...messagePasswordUpdate,
-        message: "Er is iets mis gegaan met het updaten van je wachtwoord",
-        color: "text-holon-red",
-      });
-    }
+    });
   }
-
-  /*deze functie wordt later toegevoegd
-  function handleRemoveProfile(e) {
-    console.log("profiel verwijderd");
-  }
-  */
 
   return (
     <div className="flex flex-col items-center m-8">

--- a/frontend/components/UserProfile/UserProfile.tsx
+++ b/frontend/components/UserProfile/UserProfile.tsx
@@ -26,7 +26,10 @@ export default function UserProfile() {
     email: "",
   });
   const [messageProfileUpdate, setMessageProfileUpdate] = useState("");
-  const [messagePasswordUpdate, setMessagePasswordUpdate] = useState("");
+  const [messagePasswordUpdate, setMessagePasswordUpdate] = useState({
+    message: "",
+    color: "text-holon-blue-900",
+  });
 
   useEffect(() => {
     user &&
@@ -83,7 +86,7 @@ export default function UserProfile() {
   async function handleUpdatePassword(e: React.SyntheticEvent<HTMLInputElement, SubmitEvent>) {
     e.preventDefault();
 
-    const response = await fetch(`${API_URL}dj-rest-auth/password/change/`, {
+    const response = await fetch(`${API_URL}/dj-rest-auth/password/change/`, {
       method: "POST",
       body: JSON.stringify({
         old_password: userData.currentPassword,
@@ -101,15 +104,26 @@ export default function UserProfile() {
 
     if (message.old_password) {
       if (message.old_password[0].includes("incorrectly")) {
-        setMessagePasswordUpdate(
-          "Je huidige wachtwoord is niet correct. Hierdoor kunnen we geen nieuw wachtwoord aanmaken."
-        );
+        setMessagePasswordUpdate({
+          ...messagePasswordUpdate,
+          message:
+            "Je huidige wachtwoord is niet correct. Hierdoor kunnen wij helaas geen nieuw wachtwoord aanmaken.",
+          color: "text-holon-red",
+        });
       }
     } else if (res.ok) {
-      setMessagePasswordUpdate("Je nieuwe wachtwoord is succesvol aangemaakt.");
+      setMessagePasswordUpdate({
+        ...messagePasswordUpdate,
+        message: "Je nieuwe wachtwoord is succesvol aangemaakt.",
+        color: "text-holon-blue-900",
+      });
       setUserData({ ...userData, currentPassword: "", password: "", verifyPassword: "" });
     } else {
-      setMessagePasswordUpdate("Er is iets mis gegaan met het updaten van je wachtwoord");
+      setMessagePasswordUpdate({
+        ...messagePasswordUpdate,
+        message: "Er is iets mis gegaan met het updaten van je wachtwoord",
+        color: "text-holon-red",
+      });
     }
   }
 
@@ -186,8 +200,8 @@ export default function UserProfile() {
             handleSubmit={handleUpdatePassword}
             input={userData}
             setMessage={setMessagePasswordUpdate}
+            message={messagePasswordUpdate}
           />
-          <p>{messagePasswordUpdate}</p>
         </div>
 
         {/*}

--- a/frontend/components/UserProfile/UserProfile.tsx
+++ b/frontend/components/UserProfile/UserProfile.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from "react";
 import UpdatePassword from "./UpdatePassword";
 import useUser from "@/utils/useUser";
-import { updateProfile, updatePassword } from "@/api/auth";
+import { updateProfile, updatePassword } from "../../api/auth";
 
 export type UserData = {
   first_name: string;


### PR DESCRIPTION
This pull request solves issue #340 . 

 Inloggen: Als je bent ingelogd wordt je doorverwezen naar de homepage (en niet naar je profiel zoals nu);
 Header: De username in de header moet een link zijn naar je profiel;
 Header: Als je een voornaam hebt ingevuld staat deze in de header, anders je username (nu is dat altijd je username);
 Profiel: als je bij ww wijzigen je oude wachtwoord niet goed hebt ingevuld krijg je hier een specifieke foutmelding van;
 Profiel: foutmelding bij ww wijzigen liefst in rood (fout) of blauw (goed) en tussen onderste inputfield en button in;
 api calls in een bestand zetten