### PR TITLE
Use option attribute value again for api

### DIFF
--- a/frontend/components/Blocks/SectionBlock/ContentColumn.tsx
+++ b/frontend/components/Blocks/SectionBlock/ContentColumn.tsx
@@ -97,7 +97,7 @@ export default function ContentColumn({
       case "single_select":
         const selectedOption = currentElement.value.options.find(option => option.id === optionId);
         if (!selectedOption) break;
-        currentElement.currentValue = selectedOption.id;
+        currentElement.currentValue = selectedOption.option;
         break;
       case "continuous":
         currentElement.currentValue = Number(value);
@@ -108,9 +108,9 @@ export default function ContentColumn({
         if (!currentOption) break;
         const tempArray = new Set(currentElement.currentValue);
         if (value) {
-          tempArray.add(currentOption.id);
+          tempArray.add(currentOption.option);
         } else {
-          tempArray.delete(currentOption.id);
+          tempArray.delete(currentOption.option);
         }
         currentElement.currentValue = [...tempArray];
         break;

--- a/frontend/components/Blocks/SectionBlock/ContentColumn.tsx
+++ b/frontend/components/Blocks/SectionBlock/ContentColumn.tsx
@@ -1,8 +1,8 @@
-import React, { useEffect } from "react";
-import { Content, InteractiveContent } from "./types";
 import { StaticImage } from "@/components/ImageSelector/types";
 import InteractiveInputs from "@/components/InteractiveInputs/InteractiveInputs";
 import RawHtml from "@/components/RawHtml/RawHtml";
+import React, { useEffect } from "react";
+import { Content, InteractiveContent } from "./types";
 
 type ContentColumn = {
   dataContent: Content[];
@@ -53,7 +53,7 @@ export default function ContentColumn({
           )?.option;
         } else {
           const option = content.value.options.find(option => option.default);
-          return option ? option.id : content.value.options[0].id;
+          return option ? option.option : content.value.options[0].option;
         }
       case "continuous":
         if (defaultValue !== undefined && defaultValue !== "") {
@@ -74,7 +74,7 @@ export default function ContentColumn({
             defaultValueArray?.includes(option.option) ||
             defaultValueArray?.includes(option.label)
         );
-        return defaultOptions.length ? defaultOptions.map(option => option.id) : [];
+        return defaultOptions.length ? defaultOptions.map(option => option.option) : [];
     }
   }
 

--- a/frontend/components/InteractiveInputs/InteractiveInputs.tsx
+++ b/frontend/components/InteractiveInputs/InteractiveInputs.tsx
@@ -76,7 +76,7 @@ function InteractiveRadios({
             }
             className="flex flex-row mb-2 gap-4 items-center">
             <input
-              defaultChecked={defaultCheckedValue.includes(inputItem.id)}
+              defaultChecked={defaultCheckedValue.includes(inputItem.option)}
               type={inputType}
               name={name + contentId}
               id={contentId + inputItem.id + (selectedLevel ? "holarchy" : "storyline") + "input"}

--- a/src/holon/models/rule_mapping.py
+++ b/src/holon/models/rule_mapping.py
@@ -19,8 +19,8 @@ def get_scenario_and_apply_rules(
         if interactive_element.type == ChoiceType.CHOICE_CONTINUOUS:
             interactive_element_options = interactive_element.continuous_values.all()
         else:  # single and multi select
-            ids = interactive_element_input["value"].split(",")
-            interactive_element_options = interactive_element.options.filter(id__in=ids)
+            options = interactive_element_input["value"].split(",")
+            interactive_element_options = interactive_element.options.filter(option__in=options)
 
         for option in interactive_element_options:
             value = (

--- a/src/holon/tests/test_rule_mapping_options.py
+++ b/src/holon/tests/test_rule_mapping_options.py
@@ -56,7 +56,7 @@ class RuleMappingTestClass(TestCase):
         # Arange
         interactive_elements = [
             {
-                "value": str(self.interactive_element_option_1.id),
+                "value": str(self.interactive_element_option_1.option),
                 "interactive_element": self.interactive_element,
             }
         ]
@@ -78,7 +78,7 @@ class RuleMappingTestClass(TestCase):
         # Arange
         interactive_elements = [
             {
-                "value": str(self.interactive_element_option_3.id),
+                "value": str(self.interactive_element_option_3.option),
                 "interactive_element": self.interactive_element,
             }
         ]
@@ -99,7 +99,7 @@ class RuleMappingTestClass(TestCase):
         # Arange
         interactive_elements = [
             {
-                "value": f"{self.interactive_element_option_1.id},{self.interactive_element_option_3.id}",
+                "value": f"{self.interactive_element_option_1.option},{self.interactive_element_option_3.option}",
                 "interactive_element": self.interactive_element,
             }
         ]


### PR DESCRIPTION
Gebruik weer het option veld van InteractiveElementOption voor de api om aan te geven welke optie geselecteerd is. Hierdoor kan als de default van een interactive element wordt overschreven bij het instellen van een pagina (?) de option value gebruikt worden ipv het id. Id is lastig op te zoeken in het CMS.