### PR TITLE
docker: align image versions

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -9,7 +9,7 @@ services:
         # Update 'VARIANT' to pick a version of Python: 3, 3.10, 3.9, 3.8, 3.7, 3.6
         # Append -bullseye or -buster to pin to an OS version.
         # Use -bullseye variants on local arm64/Apple Silicon.
-        VARIANT: 3-bullseye
+        VARIANT: 3.9-bullseye
         # Optional Node.js version to install
         NODE_VERSION: "16"
     env_file: .env
@@ -27,7 +27,7 @@ services:
     # Use "forwardPorts" in **devcontainer.json** to forward an app port locally.
     # (Adding the "ports" property to this file will not forward from a Codespace.)
   db:
-    image: postgres:latest
+    image: postgres:13.9
     restart: unless-stopped
     volumes:
       - postgres-data:/var/lib/postgresql/data

--- a/.github/workflows/django-code-quality.yml
+++ b/.github/workflows/django-code-quality.yml
@@ -22,7 +22,7 @@ jobs:
       AL_API_KEY: test-api-key
     services:
       postgres_main:
-        image: postgres:12
+        image: postgres:13.9
         env:
           POSTGRES_USER: ${{ env.DB_USER }}
           POSTGRES_PASSWORD: ${{ env.DB_PASSWORD }}
@@ -30,9 +30,9 @@ jobs:
         ports:
           - 5432:5432
         options: >-
-          --health-cmd pg_isready 
-          --health-interval 10s 
-          --health-timeout 5s 
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
           --health-retries 5
     strategy:
       max-parallel: 4

--- a/db/Dockerfile
+++ b/db/Dockerfile
@@ -1,4 +1,5 @@
-FROM postgres:12 as db
+# Same version as on Azure
+FROM postgres:13.9 as db
 WORKDIR /app
 COPY init.sh /docker-entrypoint-initdb.d
 COPY prod.sql /scripts/db/dump.sql

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3.1"
 services:
   web:
-    image: nginx:alpine
+    image: nginx:1.25.0-alpine3.17
     working_dir: /app
     ports:
       - "80:80"

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM nginx:alpine
+FROM nginx:1.25.0-alpine3.17
 
 COPY ./files/config/nginx.conf.template /etc/nginx/templates/default.conf.template
 COPY ./files/config/nginx.conf /etc/nginx/nginx.conf

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,6 +1,6 @@
-FROM node:alpine
+FROM node:16.20.0-alpine3.17
 
-RUN mkdir -p /usr/src/app 
+RUN mkdir -p /usr/src/app
 
 WORKDIR /usr/src/app
 

--- a/frontend/prod.Dockerfile
+++ b/frontend/prod.Dockerfile
@@ -1,5 +1,5 @@
 # Install dependencies only when needed
-FROM node:16-alpine AS deps
+FROM node:16.20.0-alpine3.17 AS deps
 # Check https://github.com/nodejs/docker-node/tree/b4117f9333da4138b03a546ec926ef50a31506c3#nodealpine to understand why libc6-compat might be needed.
 RUN apk add --no-cache libc6-compat
 WORKDIR /app
@@ -10,7 +10,7 @@ RUN npm ci
 
 
 # Rebuild the source code only when needed
-FROM node:16-alpine AS builder
+FROM node:16.20.0-alpine3.17 AS builder
 WORKDIR /app
 COPY --from=deps /app/node_modules ./node_modules
 COPY . .
@@ -26,7 +26,7 @@ RUN npm run build
 # RUN npm run build
 
 # Production image, copy all the files and run next
-FROM node:16-alpine AS runner
+FROM node:16.20.0-alpine3.17 AS runner
 WORKDIR /app
 
 ENV NODE_ENV production


### PR DESCRIPTION
Set a specific version for nginx, node, postgres and python so that
it doesn't break due to a stale image version in the local cache or
the release of a new (major) version.

Also align production and development versions.