### PR TITLE
Fallbacks when there is no interactive input selected in the backend

### DIFF
--- a/frontend/components/Blocks/HolarchyFeedbackImage/HolarchyFeedbackImage.tsx
+++ b/frontend/components/Blocks/HolarchyFeedbackImage/HolarchyFeedbackImage.tsx
@@ -1,6 +1,6 @@
-import React, { useEffect, useState } from "react";
-import { StaticImage } from "@/components/ImageSelector/types";
 import { Content } from "@/components/Blocks/SectionBlock/types";
+import { StaticImage } from "@/components/ImageSelector/types";
+import React, { useEffect, useState } from "react";
 
 export type HolarchyFeedbackImageProps = {
   id: string;
@@ -44,7 +44,7 @@ export default function HolarchyFeedbackImage({ content, holarchyfeedbackimages 
           for (const conditionItem of feedbackimage.value.conditions) {
             //inputvalue is the vaule of the assessed validator
             const inputvalue = content?.find(
-              content => content.value.id == parseFloat(conditionItem.value.parameter)
+              content => content.value?.id == parseFloat(conditionItem.value.parameter)
             )?.currentValue;
 
             const conditionValue = parseFloat(conditionItem.value.value);

--- a/frontend/components/Blocks/SectionBlock/ContentColumn.tsx
+++ b/frontend/components/Blocks/SectionBlock/ContentColumn.tsx
@@ -44,37 +44,39 @@ export default function ContentColumn({
   }, [dataContent]);
 
   function getDefaultValue(content: InteractiveContent): string | number | string[] | undefined {
-    const defaultValue = content.value.defaultValueOverride;
-    switch (content.value.type) {
-      case "single_select":
-        if (defaultValue) {
-          return content.value.options.find(
-            option => option.option === defaultValue || option.label === defaultValue
-          )?.id;
-        } else {
-          const option = content.value.options.find(option => option.default);
-          return option ? option.option : content.value.options[0].option;
-        }
-      case "continuous":
-        if (defaultValue !== undefined && defaultValue !== "") {
-          return Number(defaultValue);
-        } else if (
-          content.value.options.length &&
-          content.value.options[0].sliderValueDefault !== undefined
-        ) {
-          return Number(content.value.options[0].sliderValueDefault);
-        } else {
-          return 0;
-        }
-      case "multi_select":
-        const defaultValueArray = defaultValue && defaultValue.split(",");
-        const defaultOptions = content.value.options.filter(
-          option =>
-            option.default ||
-            defaultValueArray?.includes(option.option) ||
-            defaultValueArray?.includes(option.label)
-        );
-        return defaultOptions.length ? defaultOptions.map(option => option.option) : [];
+    if (content.value) {
+      const defaultValue = content.value.defaultValueOverride;
+      switch (content.value.type) {
+        case "single_select":
+          if (defaultValue) {
+            return content.value.options.find(
+              option => option.option === defaultValue || option.label === defaultValue
+            )?.id;
+          } else {
+            const option = content.value.options.find(option => option.default);
+            return option ? option.option : content.value.options[0].option;
+          }
+        case "continuous":
+          if (defaultValue !== undefined && defaultValue !== "") {
+            return Number(defaultValue);
+          } else if (
+            content.value.options.length &&
+            content.value.options[0].sliderValueDefault !== undefined
+          ) {
+            return Number(content.value.options[0].sliderValueDefault);
+          } else {
+            return 0;
+          }
+        case "multi_select":
+          const defaultValueArray = defaultValue && defaultValue.split(",");
+          const defaultOptions = content.value.options.filter(
+            option =>
+              option.default ||
+              defaultValueArray?.includes(option.option) ||
+              defaultValueArray?.includes(option.label)
+          );
+          return defaultOptions.length ? defaultOptions.map(option => option.option) : [];
+      }
     }
   }
 
@@ -128,7 +130,7 @@ export default function ContentColumn({
       data-empty="Er zijn er geen interactieve elementen in te stellen op dit niveau."
       className="before:empty:content-[attr(data-empty)]">
       {content.map((ct, index) => {
-        if (ct.type === "interactive_input" && ct.value.visible) {
+        if (ct.type && ct.value && ct.type === "interactive_input" && ct.value.visible) {
           return (
             <React.Fragment key={index}>
               <InteractiveInputs

--- a/src/main/blocks/storyline_section.py
+++ b/src/main/blocks/storyline_section.py
@@ -59,7 +59,7 @@ class InteractiveInputBlock(blocks.StructBlock):
     )
 
     def get_api_representation(self, value, context=None):
-        if value:
+        if value and value["interactive_input"] is not None:
             interactive_input = InteractiveElement.objects.get(pk=value["interactive_input"].id)
             options_arr = []
             if (


### PR DESCRIPTION
Een aantal fixes die bij een uitzonderelijke situatie - namelijk een niet geselecteerde interactive input, iets wat alleen mogelijk is via bijvoorbeeld een fixture en niet via het CMS - waarbij de applicatie nu niet meer crasht, maar er slechts minder fraai uit ziet (omdat er geen content is).