### PR TITLE
600 Remove relation options for model_attribute in the CMS

### DIFF
--- a/src/holon/static/js/holon_chooser.js
+++ b/src/holon/static/js/holon_chooser.js
@@ -192,9 +192,11 @@ function setAssetAttributes(model_type_select, model_subtype_select, data) {
         .closest(".w-panel__content")
         .find("input[id$='-asset_attribute'], input[id$='-model_attribute']");
 
-    const options = model_subtype_select.val()
-        ? data[model_type].model_subtype[model_subtype_select.val()]
-        : data[model_type].attributes;
+    const options = (
+        model_subtype_select.val()
+            ? data[model_type].model_subtype[model_subtype_select.val()]
+            : data[model_type].attributes
+    ).filter((option) => !option.relation); // Exclude foreign keys for model_attribute
 
     attributeInputs.each(function () {
         convertInputToSelect($(this), options);

--- a/src/holon/static/js/holon_chooser.js
+++ b/src/holon/static/js/holon_chooser.js
@@ -386,9 +386,11 @@ function updateAssetAttributes(model_type_select, model_subtype_select, data) {
         const attribute_select = $(this);
         attribute_select.find("option").remove().end();
 
-        const options = model_subtype_select.val()
-            ? data[model_type].model_subtype[model_subtype_select.val()]
-            : data[model_type].attributes;
+        const options = (
+            model_subtype_select.val()
+                ? data[model_type].model_subtype[model_subtype_select.val()]
+                : data[model_type].attributes
+        ).filter((option) => !option.relation); // Exclude foreign keys for model_attribute
 
         for (const value of options) {
             attribute_select.append(


### PR DESCRIPTION
Remove relation/foreign key options for model_attribute dropdown in the CMS. Foreign keys can't be used for filtering, as the ids are not stable.

Closes #600