### PR TITLE
Fix group and subgroup as valid actor attribute options

### DIFF
--- a/src/holon/models/filter.py
+++ b/src/holon/models/filter.py
@@ -7,7 +7,7 @@ from modelcluster.fields import ParentalKey
 from polymorphic.models import PolymorphicModel
 from wagtail.admin.edit_handlers import FieldPanel
 
-from holon.models.util import all_subclasses, is_exclude_field
+from holon.models.util import all_subclasses, is_exclude_field, is_allowed_relation
 
 
 # Don't forget to register new filters in get_filters() of ScenarioRule
@@ -38,7 +38,7 @@ class Filter(PolymorphicModel):
         return [
             field.name
             for field in model()._meta.get_fields()
-            if not field.is_relation and not is_exclude_field(field)
+            if is_allowed_relation(field) or (not field.is_relation and not is_exclude_field(field))
         ]
 
     class Meta:
@@ -148,7 +148,7 @@ class RelationAttributeFilter(Filter):
         return [
             field.name
             for field in relation_model._meta.get_fields()
-            if not field.is_relation and not is_exclude_field(field)
+            if is_allowed_relation(field) or (not field.is_relation and not is_exclude_field(field))
         ]
 
     def relation_field_options(self) -> list[str]:

--- a/src/holon/models/util.py
+++ b/src/holon/models/util.py
@@ -138,3 +138,8 @@ def is_exclude_field(field):
         return True
     else:
         return False
+
+
+def is_allowed_relation(field):
+    # group and subgroup of Actor have stable id's, so they can be used for filtering
+    return field.name == "group" or field.name == "subgroup"

--- a/src/holon/tests/test_filter.py
+++ b/src/holon/tests/test_filter.py
@@ -259,3 +259,22 @@ class RuleFiltersTestClass(TestCase):
         # Assert
         self.assertEqual(len(filtered_queryset), 1)
         self.assertEqual(filtered_queryset[0].id, asset_related_to_district_heat.id)
+
+    def test_stable_id_relation_in_model_attribute_options(self):
+        """Test if stable id relations are included for actor"""
+        # Arange
+        rule: Rule = Rule.objects.create(model_type=ModelType.ACTOR)
+
+        filter: AttributeFilter = AttributeFilter.objects.create(
+            rule=rule,
+            model_attribute="group",
+            comparator=AttributeFilterComparator.EQUAL,
+            value=1,
+        )
+
+        # Act
+        options: list[str] = filter.model_attribute_options()
+
+        # Assert
+        self.assertTrue("group" in options)
+        self.assertTrue("subgroup" in options)


### PR DESCRIPTION
Add group and subgroup as valid options for Actor, because they have stable ids. Before they were excluded, because they're relations