### PR TITLE
Fix clean function for relation attribute filter

### DIFF
--- a/src/holon/models/filter.py
+++ b/src/holon/models/filter.py
@@ -141,7 +141,7 @@ class RelationAttributeFilter(Filter):
         relation_model_type = (
             self.relation_field_subtype
             if self.relation_field_subtype
-            else model._meta.get_field(self.relation_field).name
+            else model._meta.get_field(self.relation_field).related_model.__name__
         )
         relation_model = apps.get_model("holon", relation_model_type)
 

--- a/src/holon/tests/test_filter.py
+++ b/src/holon/tests/test_filter.py
@@ -278,3 +278,24 @@ class RuleFiltersTestClass(TestCase):
         # Assert
         self.assertTrue("group" in options)
         self.assertTrue("subgroup" in options)
+
+    def test_relation_attribute_options_no_subtype_successful(self):
+        # Arange
+        rule = Rule.objects.create(
+            model_type=ModelType.GRIDCONNECTION,
+            model_subtype="",
+        )
+
+        filter = RelationAttributeFilter.objects.create(
+            rule=rule,
+            model_attribute="capacity_kw",
+            comparator=AttributeFilterComparator.GREATER_THAN,
+            value=700.0,
+            relation_field="parent_heat",
+        )
+
+        # Act
+        options = filter.relation_model_attribute_options()
+
+        # Assert
+        self.assertTrue(len(options) > 0)


### PR DESCRIPTION
Fixes clean function of RelationAttributeFilter when no subtype has been used

Closes #627 