### PR TITLE
sets option.option instead of option.id as default value interactive …

### DIFF
--- a/frontend/components/Blocks/SectionBlock/ContentColumn.tsx
+++ b/frontend/components/Blocks/SectionBlock/ContentColumn.tsx
@@ -59,7 +59,7 @@ export default function ContentColumn({
           if (defaultValue) {
             return content.value.options.find(
               option => option.option === defaultValue || option.label === defaultValue
-            )?.id;
+            )?.option;
           } else if (content.value.visible) {
             const option = content.value.options.find(option => option.default);
             return option ? option.option : content.value.options[0].option;
@@ -67,7 +67,7 @@ export default function ContentColumn({
             if (targetValue) {
               return content.value.options.find(
                 option => option.option === targetValue || option.label === targetValue
-              )?.id;
+              )?.option;
             } else {
               return null;
             }


### PR DESCRIPTION
This PR solves the bug in issue #661 

Voor single selects werd de id van de default option meegestuurd. Dit zat er al in en was daarna ook ingesteld voor de target value. Als je interactie had met het element werd dit omgezet naar de naam van de optie. 

In de default en/of target value wordt nu ook de naam van de optie gebruikt als waarde.  