### PR TITLE
add `RETURN_SCENARIO` env variables

### DIFF
--- a/.devcontainer/.env.example
+++ b/.devcontainer/.env.example
@@ -8,6 +8,7 @@ ALLOWED_HOSTS=localhost
 
 #Anylogic
 AL_API_KEY=al_api_key
+RETURN_SCENARIO=True # setting that is used in the HOLON view to determine whether to send back the used scenario (through the serializer) or not
 
 #DATABASE
 DATABASE=postgres

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ This repo contains the webapp part of the HOLON project. This includes the NextJ
   - [Deployment](#deployment)
   - [Datamodel](#datamodel)
     - [Development on datamodel](#development-on-datamodel)
+    - [Datamodel scenario feedback in any environment](#datamodel-scenario-feedback-in-any-environment)
 - [Resetting database and building project](#resetting-database-and-building-project)
 
 ## Environments
@@ -194,6 +195,14 @@ Refer to the datamodel readme: [datamodel.readme.md](src/holon/datamodel.readme.
 ### Development on datamodel
 
 Use convenience `migrate_and_create_fixture.sh` before every commit to make sure that the fixtures or present datamodels survive the changes you are making to the datamodel.
+
+### Datamodel scenario feedback in any environment
+
+A feature to help debug AnyLogic model results. This setting is used in the `/wt/api/nextjs/v2/holon/` endpoint to determine whether to send back the used scenario (through the serializer) or not. This should ideally not be set to true in production since it will impact performance.
+
+```conf
+RETURN_SCENARIO=True
+```
 
 # Resetting database and building project
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,6 +31,7 @@ services:
       - WAGTAIL_API_URL=http://python:8000/wt/
       - NEXT_PUBLIC_WAGTAIL_API_URL=https://pizzaoven.holontool.nl/wt/api/nextjs
       - NEXT_PUBLIC_BASE_URL=https://pizzaoven.holontool.nl/wt
+      - RETURN_SCENARIO=True
 
   python:
     build:

--- a/src/holon/services/data.py
+++ b/src/holon/services/data.py
@@ -5,6 +5,7 @@ import numpy as np
 
 from holon.models import Scenario
 from holon.serializers import ScenarioSerializer
+from pipit.settings import get_env_bool
 
 
 class Results:
@@ -59,9 +60,8 @@ class Results:
         return result
 
     def __include_scenario(self):
-        """Only include modified scenario if request is done locally or on acceptatie"""
-        uri = self.request.build_absolute_uri()
-        return "localhost" in uri or "acceptatie" in uri or "pizzaoven" in uri
+        """Only include modified scenario if env variable is set"""
+        return get_env_bool("RETURN_SCENARIO", False)
 
 
 def calculate_holon_kpis(anylogic_outcomes: dict) -> dict:


### PR DESCRIPTION

### Datamodel scenario feedback in any environment

A feature to help debug AnyLogic model results. This setting is used in the `/wt/api/nextjs/v2/holon/` endpoint to determine whether to send back the used scenario (through the serializer) or not. This should ideally not be set to true in production since it will impact performance.

```conf
RETURN_SCENARIO=True
```

One thing I'm unsure of is whether setting the Azure settings to this setting will be able to toggle this functionality without having to push a new container. If yes, then we can use this setting to develop with the content on main and later disable the functionality when we are happy with the outcomes.