### PR TITLE
sentry: consolidate database spans

### DIFF
--- a/src/holon/views/holon.py
+++ b/src/holon/views/holon.py
@@ -168,6 +168,7 @@ class HolonScenarioCleanup(generics.RetrieveAPIView):
                 pprint(f"... deleted scenario {cid}")
         except Exception as e:
             pprint(traceback.format_exc())
+
             response_body = {"error_msg": f"something went wrong: {e}"}
             return Response(
                 response_body,

--- a/src/pipit/sentry.py
+++ b/src/pipit/sentry.py
@@ -1,0 +1,96 @@
+import logging
+from collections import defaultdict
+from datetime import datetime, timedelta
+
+import sentry_sdk
+from sentry_sdk.integrations.django import DjangoIntegration
+
+
+def initialize_sentry(ingest_dsn: str, environment: str) -> None:
+    if ingest_dsn == "":
+        return
+
+    sentry_sdk.init(
+        dsn=ingest_dsn,
+        environment=environment,
+        debug=False,
+        traces_sample_rate=1.0,
+        integrations=[
+            DjangoIntegration(
+                # Nothing interesting here
+                middleware_spans=False,
+                # Wagtail produces a lot of signals
+                signals_spans=False,
+            )
+        ],
+        release="0.1.0",
+        # We do too many queries on some pages.
+        # Is there a better way to reduce the number of spans?
+        _experiments={"max_spans": 20_000},  # default 1000
+        before_send_transaction=consolidate_db_spans_nothrow,
+    )
+
+
+def consolidate_db_spans_nothrow(event: dict[str, any], hint: dict[str, any]) -> dict[str, any]:
+    try:
+        return consolidate_db_spans(event, hint)
+    # Don't emit exception because it will cause Sentry to not submit the transaction.
+    except Exception as e:
+        logging.exception("Error consolidating database spans")
+        return event
+
+
+# Some actions produce many database queries. This exceeds the span limit of Sentry (1000).
+# This function merges those spans so there is enough room left to send more relevant data.
+def consolidate_db_spans(event: dict[str, any], hint: dict[str, any]) -> dict[str, any]:
+    new_spans: list[dict[str, any]] = []
+
+    db_events_per_parent_span: dict[str, list[dict[str, any]]] = defaultdict(list)
+
+    for span in event["spans"]:
+        if span["op"] != "db":
+            new_spans.append(span)
+            continue
+
+        db_events_per_parent_span[span["parent_span_id"]].append(span)
+
+    for spans in db_events_per_parent_span.values():
+        if len(spans) == 1:
+            # This span is the only database query within its parent span.
+            # Include this as-is.
+            new_spans.append(spans[0])
+            continue
+
+        start_timestamp = spans[0]["start_timestamp"]
+        timestamp = spans[0]["timestamp"]
+        duration_s = 0.0
+
+        for span in spans:
+            start_timestamp = min(start_timestamp, span["start_timestamp"])
+            timestamp = max(timestamp, span["timestamp"])
+
+            t1 = datetime.fromisoformat(span["start_timestamp"])
+            t2 = datetime.fromisoformat(span["timestamp"])
+
+            duration_s += (t2 - t1).total_seconds()
+
+        consolidated_span = {
+            "trace_id": spans[0]["trace_id"],
+            "span_id": spans[0]["span_id"],
+            "parent_span_id": spans[0]["parent_span_id"],
+            "same_process_as_parent": True,
+            "op": "db",
+            "description": f"consolidated span of {len(spans)} database queries",
+            "data": {
+                "Number of queries": len(spans),
+                "Consolidated Duration": f"{round(duration_s * 1000, 2)}ms",
+            },
+            "start_timestamp": start_timestamp,
+            "timestamp": timestamp,
+        }
+
+        new_spans.append(consolidated_span)
+
+    event["spans"] = new_spans
+
+    return event

--- a/src/pipit/settings/__init__.py
+++ b/src/pipit/settings/__init__.py
@@ -1,11 +1,8 @@
 from __future__ import absolute_import, unicode_literals
 
 import os
-from typing import Optional, Dict, Any
 
 from django.core.exceptions import ImproperlyConfigured
-import sentry_sdk
-from sentry_sdk.integrations.django import DjangoIntegration
 
 
 def get_env(name, default=None):
@@ -22,36 +19,3 @@ def get_env(name, default=None):
 
 def get_env_bool(name, default=None):
     return get_env(name, default=default) == "True"
-
-
-def initialize_sentry(ingest_dsn: str, environment: str) -> None:
-    if ingest_dsn == "":
-        return
-
-    sentry_sdk.init(
-        dsn=ingest_dsn,
-        environment=environment,
-        debug=False,
-        traces_sample_rate=1.0,
-        integrations=[
-            DjangoIntegration(
-                # Nothing interesting here
-                middleware_spans=False,
-                # Wagtail produces a lot of signals
-                signals_spans=False,
-            )
-        ],
-        release="0.1.0",
-        # We do too many queries on some pages.
-        # Is there a better way to reduce the number of spans?
-        _experiments={"max_spans": 5000},  # default 1000
-        before_send_transaction=remove_db_spans,
-    )
-
-
-# Some actions produce many database queries. This exceeds the span limit of Sentry (1000).
-# This function removes those spans so there is enough room left to send more relevant data.
-def remove_db_spans(event: Dict[str, Any], hint: Dict[str, Any]) -> Optional[Dict[str, Any]]:
-    event["spans"] = [span for span in event["spans"] if span["op"] != "db"]
-
-    return event

--- a/src/pipit/settings/local.py
+++ b/src/pipit/settings/local.py
@@ -1,7 +1,7 @@
 """
 Write local settings here, or override base settings
 """
-from pipit.settings import initialize_sentry
+from pipit.sentry import initialize_sentry
 from pipit.settings.base import *  # NOQA
 
 WAGTAILADMIN_BASE_URL = "http://localhost:8000"

--- a/src/pipit/settings/prod.py
+++ b/src/pipit/settings/prod.py
@@ -1,7 +1,7 @@
 """
 Write prod settings here, or override base settings
 """
-from pipit.settings import initialize_sentry
+from pipit.sentry import initialize_sentry
 from pipit.settings.base import *  # NOQA
 
 

--- a/src/pipit/settings/stage.py
+++ b/src/pipit/settings/stage.py
@@ -3,7 +3,7 @@ Write stage settings here, or override base settings
 """
 from sentry_sdk import configure_scope
 
-from pipit.settings import initialize_sentry
+from pipit.sentry import initialize_sentry
 from pipit.settings.base import *  # NOQA
 
 


### PR DESCRIPTION
Instead of removing the database spans from distributed tracing, merge spans which have the same parent. This way Sentry still gives some insight in the database usage.

Example output:

![Screenshot from 2023-04-26 15-16-26](https://user-images.githubusercontent.com/1748197/234590003-24b59259-135f-4d46-bd8e-8abf67f3e5fd.png)
