### PR TITLE
sentry: log ETM variables

### DIFF
--- a/src/holon/models/rule_mapping.py
+++ b/src/holon/models/rule_mapping.py
@@ -1,9 +1,12 @@
+import sentry_sdk
+
 from holon.models.scenario import Scenario
 from holon.models.scenario_rule import ScenarioRule
 from holon.serializers import InteractiveElementInput
 from holon.models import ChoiceType
 
 
+@sentry_sdk.trace
 def get_scenario_and_apply_rules(
     scenario_id: int, interactive_element_inputs: list[InteractiveElementInput]
 ) -> Scenario:

--- a/src/holon/services/cloudclient/client.py
+++ b/src/holon/services/cloudclient/client.py
@@ -1,5 +1,6 @@
 import json
 
+import sentry_sdk
 from anylogiccloudclient.client.cloud_client import CloudClient as ALCloudClient
 from anylogiccloudclient.client.cloud_client import Inputs
 from anylogiccloudclient.client.single_run_outputs import SingleRunOutputs
@@ -63,6 +64,7 @@ class CloudClient:
 
         return ScenarioSerializer(scenario).data
 
+    @sentry_sdk.trace
     def run(self) -> None:
         """run the scenario, outputs are set to the .outputs attribute"""
 

--- a/src/holon/views/holon.py
+++ b/src/holon/views/holon.py
@@ -5,6 +5,7 @@ from django.apps import apps
 from rest_framework import generics, status
 from rest_framework.request import Request
 from rest_framework.response import Response
+from sentry_sdk import capture_exception
 
 from holon.models import Scenario, rule_mapping
 from holon.models.scenario_rule import ModelType
@@ -98,6 +99,7 @@ class HolonV2Service(generics.CreateAPIView):
                 return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
         except Exception as e:
             pprint(traceback.format_exc())
+            capture_exception(e)
 
             response_body = {"error_msg": f"something went wrong: {e}"}
             if scenario:
@@ -168,6 +170,7 @@ class HolonScenarioCleanup(generics.RetrieveAPIView):
                 pprint(f"... deleted scenario {cid}")
         except Exception as e:
             pprint(traceback.format_exc())
+            capture_exception(e)
 
             response_body = {"error_msg": f"something went wrong: {e}"}
             return Response(


### PR DESCRIPTION
Log input and output of ETM costs and upscaling.

Example logging of cost:

![Screenshot from 2023-04-26 16-43-52](https://user-images.githubusercontent.com/1748197/234612664-090a6d6f-5ec7-4032-b0b3-306c7cf71cbf.png)

Example logging of scaling:

![Screenshot from 2023-04-26 16-38-28](https://user-images.githubusercontent.com/1748197/234612695-c45e0abd-d78c-4d95-a892-e6d2a23f4948.png)