### PR TITLE
changes order of interactive elements with target values

### DIFF
--- a/frontend/components/Blocks/ContentBlocks.tsx
+++ b/frontend/components/Blocks/ContentBlocks.tsx
@@ -41,6 +41,7 @@ const ContentBlocks = ({
   /*Adds target values of previous sections to interactive elements in the section */
   function addTargetValues(values, content) {
     const updatedContent = { ...content };
+    const uniqueTargetValues = []
 
     values.forEach((value, key) => {
       const foundElement = updatedContent.value.content.find(element => {
@@ -50,8 +51,8 @@ const ContentBlocks = ({
       if (foundElement) {
         foundElement.value.targetValuePreviousSection = value.targetValue;
       } else {
-        //if the element does not exist yet it is added (invisible and with no other defaultValues besides the target value(s))
-        updatedContent.value.content.push({
+        //if the element does not exist yet it is added to an array (the element is invisible and with no other defaultValues besides the target value(s))
+        uniqueTargetValues.unshift({
           type: "interactive_input",
           value: {
             ...value,
@@ -66,6 +67,11 @@ const ContentBlocks = ({
         });
       }
     });
+    //the array target values is placed in front of the list with interactive input elements, keeping the order in which they were placed on the page
+    uniqueTargetValues.map((item) => {
+      updatedContent.value.content.unshift(item);
+    })
+     
     return updatedContent;
   }
 

--- a/frontend/components/Blocks/ContentBlocks.tsx
+++ b/frontend/components/Blocks/ContentBlocks.tsx
@@ -36,7 +36,7 @@ const ContentBlocks = ({
   pagetype?: string;
   graphcolors?: Graphcolor[];
 }) => {
-  let targetValues = new Map();
+  let targetValuesPreviousSections = new Map();
 
   /*Adds target values of previous sections to interactive elements in the section */
   function addTargetValues(values, content) {
@@ -79,9 +79,9 @@ const ContentBlocks = ({
   function updateTargetValues(content) {
     content.map(element => {
       if (element.type === "interactive_input" && element.value.targetValue) {
-        const newTargetValues = new Map(targetValues);
+        const newTargetValues = new Map(targetValuesPreviousSections);
         newTargetValues.set(element.value.id, element.value);
-        targetValues = newTargetValues;
+        targetValuesPreviousSections = newTargetValues;
       }
     });
     return null;
@@ -110,7 +110,7 @@ const ContentBlocks = ({
           case "card_block":
             return <CardBlock key={`cardsblock ${contentItem.id}`} data={contentItem} />;
           case "section":
-            const newContent = addTargetValues(targetValues, contentItem);
+            const newContent = addTargetValues(targetValuesPreviousSections, contentItem);
             updateTargetValues(contentItem.value.content);
             return (
               <SectionBlock

--- a/frontend/components/Blocks/SectionBlock/ContentColumn.tsx
+++ b/frontend/components/Blocks/SectionBlock/ContentColumn.tsx
@@ -120,7 +120,6 @@ export default function ContentColumn({
                 targetValueArray?.includes(option.label)
             );
           }
-
           return options.length ? options.map(option => option.option) : [];
       }
     }

--- a/src/holon/models/interactive_element.py
+++ b/src/holon/models/interactive_element.py
@@ -181,7 +181,6 @@ class InteractiveElementOptions(ClusterableModel, Orderable):
     panels = [
         FieldPanel("option"),
         FieldPanel("label"),
-        FieldPanel("default"),
         FieldPanel("legal_limitation"),
         FieldPanel("level"),
         FieldPanel("color"),
@@ -252,7 +251,6 @@ class InteractiveElementContinuousValues(ClusterableModel):
     )
 
     panels = [
-        FieldPanel("slider_value_default"),
         FieldPanel("slider_value_min"),
         FieldPanel("slider_value_max"),
         FieldPanel("discretization_steps"),

--- a/src/main/blocks/storyline_section.py
+++ b/src/main/blocks/storyline_section.py
@@ -82,9 +82,6 @@ class InteractiveInputBlock(blocks.StructBlock):
                     if bool(value["default_value"]):
                         if value["default_value"].lower() == option.option.lower():
                             option_default = True
-                    elif bool(value["target_value"]):
-                        if value["target_value"].lower() == option.option.lower():
-                            option_default = True
                     else:
                         option_default = option.default
                     option_dict = {


### PR DESCRIPTION
This PR closes #701 

Instead of added the target values at the end of the array with interactive inputs it now places them at the beginning (while keeping the order in which they are added to the page). 

It also fixes a small bug in which multi-select elements where being send along with target values as default values in the section they were placed in (instead of only in their underlying sections). 

It also hides the option to give an interactive element snippet a default value. This option is not used by the modelers and it gives undesired behaviour when adding an element with a target value. 