### PR TITLE
699 dropdown performance improvements

### DIFF
--- a/src/holon/models/rule_actions/rule_action_add_set.py
+++ b/src/holon/models/rule_actions/rule_action_add_set.py
@@ -161,12 +161,17 @@ class GenericRuleActionAdd(RuleAction):
                         {
                             parent_fk_field_name: filtererd_object,
                             "contractScope": cloned_contract_scope,
+                            "is_rule_action_template": False,
                         },
                     )
 
                 else:
                     util.duplicate_model(
-                        self.model_to_add, {parent_fk_field_name: filtererd_object}
+                        self.model_to_add,
+                        {
+                            parent_fk_field_name: filtererd_object,
+                            "is_rule_action_template": False,
+                        },
                     )
 
                 objects_added += 1
@@ -267,4 +272,10 @@ class RuleActionAddMultipleUnderEachParent(GenericRuleActionAdd, ClusterableMode
         # only take first n objects
         for filtererd_object in filtered_queryset:
             for _ in range(n):
-                util.duplicate_model(self.model_to_add, {parent_fk_field_name: filtererd_object})
+                util.duplicate_model(
+                    self.model_to_add,
+                    {
+                        parent_fk_field_name: filtererd_object,
+                        "is_rule_action_template": False,
+                    },
+                )

--- a/src/holon/models/rule_actions/rule_action_balance_group.py
+++ b/src/holon/models/rule_actions/rule_action_balance_group.py
@@ -257,7 +257,10 @@ class RuleActionBalanceGroup(RuleAction, ClusterableModel):
 
             util.duplicate_model(
                 template_models_in_order[current_template_model_i],
-                {parent_fk_field_name: filtererd_object},
+                {
+                    parent_fk_field_name: filtererd_object,
+                    "is_rule_action_template": False,
+                },
             )
 
             model_add_count += 1

--- a/src/holon/templates/modelconfig.html
+++ b/src/holon/templates/modelconfig.html
@@ -1,0 +1,121 @@
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <meta charset="utf-8" />
+        <meta
+            name="viewport"
+            content="width=device-width, initial-scale=1, shrink-to-fit=no"
+        />
+
+        <title>{% block title %}{% endblock %}</title>
+
+        <link
+            rel="stylesheet"
+            href="https://cdn.jsdelivr.net/npm/bootstrap@4.0.0/dist/css/bootstrap.min.css"
+            integrity="sha384-Gn5384xqQ1aoWXA+058RXPxPg6fy4IWvTNh0E263XmFcJlSAwiGgFAW/dAiS6JXm"
+            crossorigin="anonymous"
+        />
+    </head>
+    <body>
+        <div id="accordion">
+            {% for configname, config in configs.items %}
+            <div class="card">
+                <div class="card-header" id="{{configname}}">
+                    <h5 class="mb-0">
+                        <button
+                            class="btn btn-link"
+                            data-toggle="collapse"
+                            data-target="#collapse{{configname}}"
+                            aria-expanded="true"
+                            aria-controls="collapse{{configname}}"
+                        >
+                            {{configname}}
+                        </button>
+                    </h5>
+                </div>
+
+                <div
+                    id="collapse{{configname}}"
+                    class="collapse"
+                    aria-labelledby="heading{{configname}}"
+                    data-parent="#accordion"
+                >
+                    <div class="card-body">
+                        <h5>Attributes</h5>
+                        <ul class="list-group">
+                            {% for attribute in config.attributes %}
+                            <li class="list-group-item">
+                                {{attribute.name}} 
+                                {% if attribute.relation %}
+                                    | {{attribute.relation}} 
+                                {% endif %}
+                            </li>
+                            {% endfor %}
+                        </ul>
+                        <br />
+                        <h5>Subtypes</h5>
+                        <!-- Subtypes -->
+                        <div id="accordion{{configname}}">
+                            {% for subtypename, subtypeattributes in config.model_subtype.items %}
+                            <div class="card">
+                                <div class="card-header" id="{{subtypename}}">
+                                    <h5 class="mb-0">
+                                        <button
+                                            class="btn btn-link"
+                                            data-toggle="collapse"
+                                            data-target="#collapse{{subtypename}}"
+                                            aria-expanded="true"
+                                            aria-controls="collapse{{subtypename}}"
+                                        >
+                                            {{subtypename}}
+                                        </button>
+                                    </h5>
+                                </div>
+
+                                <div
+                                    id="collapse{{subtypename}}"
+                                    class="collapse"
+                                    aria-labelledby="heading{{subtypename}}"
+                                    data-parent="#accordion{{configname}}"
+                                >
+                                    <div class="card-body">
+                                        <h5>Attributes</h5>
+                                        <ul class="list-group">
+                                            {% for subattribute in subtypeattributes %}
+                                            <li class="list-group-item">
+                                                {{subattribute.name}}
+                                                {% if subattribute.relation %}
+                                                    | {{subattribute.relation}} 
+                                                {% endif %}
+                                            </li>
+                                            {% endfor %}
+                                        </ul>
+                                    </div>
+                                </div>
+                            </div>
+                            {% endfor %}
+                        </div>
+                        <!-- Subtypes end -->
+                    </div>
+                </div>
+            </div>
+            {% endfor %}
+        </div>
+
+        <script
+            src="https://code.jquery.com/jquery-3.2.1.slim.min.js"
+            integrity="sha384-KJ3o2DKtIkvYIK3UENzmM7KCkRr/rE9/Qpg6aAZGJwFDMVNA/GpGFF93hXpG5KkN"
+            crossorigin="anonymous"
+        ></script>
+        <script
+            src="https://cdn.jsdelivr.net/npm/popper.js@1.12.9/dist/umd/popper.min.js"
+            integrity="sha384-ApNbgh9B+Y1QKtv3Rn7W3mgPxhU9K/ScQsAP7hUibX39j7fakFPskvXusvfa0b4Q"
+            crossorigin="anonymous"
+        ></script>
+        <script
+            src="https://cdn.jsdelivr.net/npm/bootstrap@4.0.0/dist/js/bootstrap.min.js"
+            integrity="sha384-JZR6Spejh4U02d8jOt6vLEHfe/JQGiRRSQQxSfFWpi1MquVdAyjUar5+76PVCmYl"
+            crossorigin="anonymous"
+        ></script>
+    </body>
+</html>

--- a/src/holon/views/holon.py
+++ b/src/holon/views/holon.py
@@ -2,6 +2,7 @@ import json
 import traceback
 
 from django.apps import apps
+from django.shortcuts import render
 from etm_service.etm_session.session import ETMConnectionError
 from rest_framework import generics, status
 from rest_framework.request import Request
@@ -209,6 +210,11 @@ class HolonCMSLogic(generics.RetrieveAPIView):
                 attribute["relation"] = field.related_model.__name__
             attributes.append(attribute)
         return attributes
+
+
+def holonCMSLogicFormatter(request):
+    configs = HolonCMSLogic().get(request)
+    return render(request, "modelconfig.html", {"configs": configs.data})
 
 
 class HolonScenarioCleanup(generics.RetrieveAPIView):

--- a/src/pipit/settings/base.py
+++ b/src/pipit/settings/base.py
@@ -60,6 +60,7 @@ INSTALLED_APPS = [
     "rest_framework",
     "rest_framework.authtoken",
     "rest_framework_simplejwt",
+    "drf_spectacular",
     "corsheaders",
     # Project specific apps
     "pipit",
@@ -125,7 +126,8 @@ TEMPLATES = [
 WSGI_APPLICATION = "pipit.wsgi.application"
 
 REST_FRAMEWORK = {
-    "DEFAULT_AUTHENTICATION_CLASSES": ("dj_rest_auth.jwt_auth.JWTCookieAuthentication",)
+    "DEFAULT_AUTHENTICATION_CLASSES": ("dj_rest_auth.jwt_auth.JWTCookieAuthentication",),
+    "DEFAULT_SCHEMA_CLASS": "drf_spectacular.openapi.AutoSchema",
 }
 REST_USE_JWT = True
 JWT_AUTH_COOKIE = "holon-auth"
@@ -272,3 +274,11 @@ CACHES = {
 
 # Disable form length for big interactive element forms
 DATA_UPLOAD_MAX_NUMBER_FIELDS = None
+
+# Openapi documentation
+SPECTACULAR_SETTINGS = {
+    "TITLE": "HOLON",
+    "DESCRIPTION": "",
+    "VERSION": "2.0.0",
+    "SERVE_INCLUDE_SCHEMA": False,
+}

--- a/src/pipit/urls.py
+++ b/src/pipit/urls.py
@@ -10,10 +10,14 @@ from wagtail import urls as wagtail_urls
 from wagtail.admin import urls as wagtailadmin_urls
 from wagtail.contrib.sitemaps.views import sitemap
 from wagtail.documents import urls as wagtaildocs_urls
+from drf_spectacular.views import (
+    SpectacularAPIView,
+    SpectacularSwaggerView,
+)
 
 from holon.urls import urlpatterns as holon_urls
 from holon.urls import urlpatterns_v2 as holon_urls_v2
-from holon.views import HolonCMSLogic
+from holon.views import HolonCMSLogic, holonCMSLogicFormatter
 from main.views.csfr import get_csrf
 from main.views.error_500 import error_500_view
 from main.views.page_not_found import PageNotFoundView
@@ -55,8 +59,15 @@ urlpatterns += [
     path("wt/api/nextjs/v1/", api_router.urls),
     path("wt/api/nextjs/v1/", include(holon_urls)),
     path("wt/api/nextjs/v2/", include(holon_urls_v2)),
+    path("wt/api/schema/", SpectacularAPIView.as_view(), name="schema"),
+    path(
+        "wt/api/schema/swagger",
+        SpectacularSwaggerView.as_view(url_name="schema"),
+        name="swagger-ui",
+    ),
     path("wt/cms/", include(wagtailadmin_urls)),
     path("wt/cms/modelconfig", HolonCMSLogic.as_view()),
+    path("wt/cms/modelconfig/schema", holonCMSLogicFormatter),
     path("wt/documents/", include(wagtaildocs_urls)),
     path("wt/sitemap.xml", sitemap, name="sitemap"),
     path("wt/dj-rest-auth/", include("dj_rest_auth.urls")),

--- a/src/requirements/base.txt
+++ b/src/requirements/base.txt
@@ -18,6 +18,7 @@ django-allauth==0.52.0
 djangorestframework-simplejwt==5.2.2
 django-rest-polymorphic==0.1.10
 wagtail-color-panel==1.4.1
+drf-spectacular==0.26.2
 
 # cloudclient
 anylogiccloudclient @ https://cloud.anylogic.com/files/api-8.5.0/clients/anylogiccloudclient-8.5.0-py3-none-any.whl#egg=anylogiccloudclient


### PR DESCRIPTION
- is_rule_action_template wordt bij toevoegen bij bijv. RuleActionAdd op false gezet, zodat deze niet in de dropdowns komt in het CMS -> Geen oplopende laaddtijden
- Caching /modelconfig had geen zin omdat dit maar enkele ms duurde
- Modelconfig wordt autmatisch leesbaar gedocumenteerd in http://localhost:8000/wt/cms/modelconfig/schema
- Api's worden automatisch gedocumenteerd in http://localhost:8000/wt/api/schema/swagger

Closes #699 

Bij goedkeuring zal ik het in de wiki zetten :)