### PR TITLE
Add group_id and subgroup_id options for CMS

### DIFF
--- a/src/holon/models/filter.py
+++ b/src/holon/models/filter.py
@@ -45,7 +45,8 @@ class Filter(PolymorphicModel):
         return [
             field.name
             for field in model()._meta.get_fields()
-            if is_allowed_relation(field) or (not field.is_relation and not is_exclude_field(field))
+            if is_allowed_relation(field.name)
+            or (not field.is_relation and not is_exclude_field(field))
         ]
 
     class Meta:
@@ -156,7 +157,8 @@ class RelationAttributeFilter(Filter):
         return [
             field.name
             for field in relation_model._meta.get_fields()
-            if is_allowed_relation(field) or (not field.is_relation and not is_exclude_field(field))
+            if is_allowed_relation(field.name)
+            or (not field.is_relation and not is_exclude_field(field))
         ]
 
     def get_q(self) -> Q:

--- a/src/holon/models/rule_actions/rule_action_change_attribute.py
+++ b/src/holon/models/rule_actions/rule_action_change_attribute.py
@@ -80,9 +80,13 @@ class RuleActionChangeAttribute(RuleAction):
         if self.static_value:
             value = self.static_value
 
+        model_attribute = self.model_attribute
+        if is_allowed_relation(model_attribute):
+            model_attribute += "_id"
+
         # apply operators to objects
         for filtered_object in filtered_queryset:
-            old_value = getattr(filtered_object, self.model_attribute)
+            old_value = getattr(filtered_object, model_attribute)
             new_value = self.__apply_operator(old_value, value)
 
             # change the new value type to the same as the old one
@@ -92,5 +96,5 @@ class RuleActionChangeAttribute(RuleAction):
                 # fallback when old_value is None
                 cast_new_value = new_value
 
-            setattr(filtered_object, self.model_attribute, cast_new_value)
+            setattr(filtered_object, model_attribute, cast_new_value)
             filtered_object.save()

--- a/src/holon/models/rule_actions/rule_action_change_attribute.py
+++ b/src/holon/models/rule_actions/rule_action_change_attribute.py
@@ -8,6 +8,9 @@ from wagtail.admin.edit_handlers import FieldPanel
 from django.db.models.query import QuerySet
 
 
+from holon.models.util import is_allowed_relation
+
+
 class ChangeAttributeOperator(models.TextChoices):
     """Types of supported mathematical operators"""
 
@@ -37,7 +40,10 @@ class RuleActionChangeAttribute(RuleAction):
         super().clean()
 
         try:
-            if not self.model_attribute in self.rule.get_model_attributes_options():
+            if (
+                not self.model_attribute in self.rule.get_model_attributes_options()
+                or not is_allowed_relation(self.model_attribute)
+            ):
                 raise ValidationError(f"Invalid value {self.model_attribute} for model_attribute")
         except ObjectDoesNotExist:
             return

--- a/src/holon/models/rule_actions/rule_action_change_attribute.py
+++ b/src/holon/models/rule_actions/rule_action_change_attribute.py
@@ -40,10 +40,7 @@ class RuleActionChangeAttribute(RuleAction):
         super().clean()
 
         try:
-            if (
-                not self.model_attribute in self.rule.get_model_attributes_options()
-                or not is_allowed_relation(self.model_attribute)
-            ):
+            if not self.model_attribute in self.rule.get_model_attributes_options():
                 raise ValidationError(f"Invalid value {self.model_attribute} for model_attribute")
         except ObjectDoesNotExist:
             return

--- a/src/holon/models/rule_actions/rule_action_change_attribute.py
+++ b/src/holon/models/rule_actions/rule_action_change_attribute.py
@@ -82,6 +82,7 @@ class RuleActionChangeAttribute(RuleAction):
 
         model_attribute = self.model_attribute
         if is_allowed_relation(model_attribute):
+            # Add id to attribute so it can be updated with an id compared to a model instance
             model_attribute += "_id"
 
         # apply operators to objects

--- a/src/holon/models/scenario_rule.py
+++ b/src/holon/models/scenario_rule.py
@@ -7,6 +7,7 @@ from modelcluster.models import ClusterableModel
 from wagtail.admin.edit_handlers import FieldPanel, InlinePanel, MultiFieldPanel
 from polymorphic.models import PolymorphicModel
 from holon.models.filter import Filter
+from holon.models.util import is_allowed_relation
 
 from holon.models.interactive_element import (
     InteractiveElementOptions,
@@ -101,7 +102,11 @@ class Rule(PolymorphicModel, ClusterableModel):
         model_type = self.model_type if self.model_subtype is None else self.model_subtype
         model = apps.get_model("holon", model_type)
 
-        return [field.name for field in model()._meta.get_fields() if not field.is_relation]
+        return [
+            field.name
+            for field in model()._meta.get_fields()
+            if not field.is_relation or is_allowed_relation(field.name)
+        ]
 
     def model_subtype_options(self) -> list[str]:
         """Get a list of subclass names of the Rule's model type"""

--- a/src/holon/models/util.py
+++ b/src/holon/models/util.py
@@ -174,7 +174,7 @@ def relation_field_subtype_options(rule: "ScenarioRule", relation_field: str) ->
     return [subclass.__name__ for subclass in all_subclasses(related_model)]
 
 
-def is_allowed_relation(field_name) -> bool:
+def is_allowed_relation(field_name: str) -> bool:
     # group and subgroup of Actor have stable id's, so they can be used for filtering
     return (
         field_name == "group"

--- a/src/holon/models/util.py
+++ b/src/holon/models/util.py
@@ -176,12 +176,7 @@ def relation_field_subtype_options(rule: "ScenarioRule", relation_field: str) ->
 
 def is_allowed_relation(field_name: str) -> bool:
     # group and subgroup of Actor have stable id's, so they can be used for filtering
-    return (
-        field_name == "group"
-        or field_name == "subgroup"
-        or field_name == "group_id"
-        or field_name == "subgroup_id"
-    )
+    return field_name == "group" or field_name == "subgroup"
 
 
 def serialize_add_models(asset_to_add, gridconnection_to_add, contract_to_add) -> tuple[str]:

--- a/src/holon/models/util.py
+++ b/src/holon/models/util.py
@@ -130,6 +130,9 @@ def is_exclude_field(field):
     if field.name.endswith("_ptr"):
         # Exclude iternal polymorphic attributes for CMS
         return True
+    if field.name == "polymorphic_ctype":
+        # Exclude iternal polymorphic attributes for CMS
+        return True
     if field.is_relation and hasattr(field, "field") and field.field.name.endswith("_ptr"):
         # Exclude iternal polymorphic attributes of relations for CMS
         return True
@@ -171,9 +174,14 @@ def relation_field_subtype_options(rule: "ScenarioRule", relation_field: str) ->
     return [subclass.__name__ for subclass in all_subclasses(related_model)]
 
 
-def is_allowed_relation(field) -> bool:
+def is_allowed_relation(field_name) -> bool:
     # group and subgroup of Actor have stable id's, so they can be used for filtering
-    return field.name == "group" or field.name == "subgroup"
+    return (
+        field_name == "group"
+        or field_name == "subgroup"
+        or field_name == "group_id"
+        or field_name == "subgroup_id"
+    )
 
 
 def serialize_add_models(asset_to_add, gridconnection_to_add, contract_to_add) -> tuple[str]:

--- a/src/holon/tests/test_rule_action_change_attribute.py
+++ b/src/holon/tests/test_rule_action_change_attribute.py
@@ -192,3 +192,28 @@ class RuleMappingTestClass(TestCase):
         # Assert
         assert updated_scenario.gridconnection_set.first().capacity_kw == 1  # was 750.0
         assert updated_scenario.gridconnection_set.first().insulation_label == 1  # was 750.0
+
+    def test_change_attribute_allowed_relation_set(self):
+        """Test the change attribute set operator"""
+
+        # Arrange
+        rule = ScenarioRule.objects.create(
+            interactive_element_continuous_values=self.interactive_element_continuous_values,
+            model_type=ModelType.ACTOR,
+        )
+        RuleActionChangeAttribute.objects.create(
+            model_attribute="group", operator=ChangeAttributeOperator.SET, rule=rule
+        )
+
+        actor_group = ActorGroup.objects.create(name="group")
+        interactive_elements = [
+            {"value": str(actor_group.id), "interactive_element": self.interactive_element}
+        ]
+
+        # Act
+        updated_scenario = rule_mapping.get_scenario_and_apply_rules(
+            self.scenario.id, interactive_elements
+        )
+
+        # Assert
+        assert updated_scenario.actor_set.first().group_id == actor_group.id

--- a/src/holon/views/holon.py
+++ b/src/holon/views/holon.py
@@ -11,7 +11,7 @@ from rest_framework.response import Response
 from holon.cache import holon_endpoint_cache
 from holon.models import Scenario, rule_mapping
 from holon.models.scenario_rule import ModelType
-from holon.models.util import all_subclasses, is_exclude_field, is_allowed_relation
+from holon.models.util import all_subclasses, is_exclude_field
 from holon.serializers import HolonRequestSerializer, ScenarioSerializer
 from holon.services import CostTables, ETMConnect
 from holon.services.cloudclient import CloudClient

--- a/src/holon/views/holon.py
+++ b/src/holon/views/holon.py
@@ -206,12 +206,8 @@ class HolonCMSLogic(generics.RetrieveAPIView):
             if is_exclude_field(field):
                 continue
             attribute = {"name": field.name}
-            if field.is_relation:
-                if issubclass(field.related_model, tuple(self.valid_relations)):
-                    attribute["relation"] = field.related_model.__name__
-                elif is_allowed_relation(field.name):
-                    extra_id_attribute = {"name": f"{field.name}_id"}
-                    attributes.append(extra_id_attribute)
+            if field.is_relation and issubclass(field.related_model, tuple(self.valid_relations)):
+                attribute["relation"] = field.related_model.__name__
             attributes.append(attribute)
         return attributes
 


### PR DESCRIPTION
De PR zorgt ervoor dat group en subgroup van een Actor veranderd kunnen worden. De id's van deze relaties blijven namelijk gelijk. Door '_id' achter het model attribuut te zetten, kan er met static value of interactief element een ander id worden meegegeven.
Voor filteren hoeft er voor django niet per se '_id' achter te staan, dus dat is zo gelaten om alles zo simpel mogelijk te houden

- [x] Test schrijven

Closes #711