### PR TITLE
735 set original

### DIFF
--- a/src/holon/rule_engine/repositories/repository_base.py
+++ b/src/holon/rule_engine/repositories/repository_base.py
@@ -22,6 +22,11 @@ class RepositoryBaseClass:
         self.assert_object_ids(objects)  # TODO make property with setter?
         self.objects = objects
 
+        # Set original id of each model
+        # This maintains backwards compatibility when id's weren't stable because of cloning in the database
+        for object in self.objects:
+            object.original_id = object.id
+
         # start an id counter at an arbitrary high number
         self.id_counter = self.id_counter_generator(objects)
 

--- a/src/holon/tests/repository/test_repository_init.py
+++ b/src/holon/tests/repository/test_repository_init.py
@@ -10,5 +10,6 @@ class RepositoryInitTestClass(unittest.TestCase):
         gridconnection_2 = HouseGridConnection(id=2)
         repository = GridConnectionRepository([gridconnection_1, gridconnection_2])
 
+        # original id should be set and the same as the objects id
         for object in repository.all():
-            assert object.original_id is not None
+            assert object.original_id is object.id

--- a/src/holon/tests/repository/test_repository_init.py
+++ b/src/holon/tests/repository/test_repository_init.py
@@ -1,0 +1,14 @@
+import unittest
+
+from holon.models import HouseGridConnection
+from holon.rule_engine.repositories import GridConnectionRepository
+
+
+class RepositoryInitTestClass(unittest.TestCase):
+    def test_init_original_ids(self):
+        gridconnection_1 = HouseGridConnection(id=1)
+        gridconnection_2 = HouseGridConnection(id=2)
+        repository = GridConnectionRepository([gridconnection_1, gridconnection_2])
+
+        for object in repository.all():
+            assert object.original_id is not None


### PR DESCRIPTION
Set original_id when creating a repository. This is to main compatibility with scenario rules that  use this attribute since the the id's were not stable