### PR TITLE
Interactive element: allow relations

### DIFF
--- a/src/holon/static/js/holon_chooser.js
+++ b/src/holon/static/js/holon_chooser.js
@@ -196,7 +196,7 @@ function setAssetAttributes(model_type_select, model_subtype_select, data) {
         model_subtype_select.val()
             ? data[model_type].model_subtype[model_subtype_select.val()]
             : data[model_type].attributes
-    ).filter((option) => !option.relation); // Exclude foreign keys for model_attribute
+    )
 
     attributeInputs.each(function () {
         convertInputToSelect($(this), options);
@@ -535,7 +535,7 @@ function updateAssetAttributes(model_type_select, model_subtype_select, data) {
             model_subtype_select.val()
                 ? data[model_type].model_subtype[model_subtype_select.val()]
                 : data[model_type].attributes
-        ).filter((option) => !option.relation); // Exclude foreign keys for model_attribute
+        )
 
         for (const value of options) {
             attribute_select.append(


### PR DESCRIPTION
Enable filtering and change relations by id with interactive elements. These options were removed with jQuery.

This is now only allowed for actor group and subgroup due to existing backend validation.

The ideal situation would be to make the front-end options dependent on the backend validation so it is always in sync. (single source of truth)