### PR TITLE
adjusts styling to new height header

### DIFF
--- a/frontend/components/Blocks/SectionBlock/CostBenefitModal/CostBenefitModal.tsx
+++ b/frontend/components/Blocks/SectionBlock/CostBenefitModal/CostBenefitModal.tsx
@@ -22,7 +22,7 @@ export default function CostBenefitModal({ handleClose, costBenefitData, graphco
   const [subgroup, setSubgroup] = useState("");
 
   useEffect(() => {
-    setSubgroup(Object.keys(costBenefitData.detail)[0]);
+    costBenefitData.detail && setSubgroup(Object.keys(costBenefitData.detail)[0]);
   }, []);
 
   const handleClick = (e: React.MouseEvent<HTMLElement>) => {
@@ -51,7 +51,7 @@ export default function CostBenefitModal({ handleClose, costBenefitData, graphco
 
   return (
     <div className="h-screen bg-white">
-      <div className="bg-white py-6 px-10 lg:px-16 fixed top-20 md:top-[5.7rem] inset-x-0 mx-auto h-[calc(100%-4.5rem)] md:h-[calc(100%-7rem)] z-30">
+      <div className="bg-white py-6 px-10 lg:px-16 fixed top-[5rem] min-[699px]:top-[5.5rem] inset-x-0 mx-auto h-[calc(100%-5rem)] md:h-[calc(100%-5.5rem)] z-30">
         <div className="block h-full w-full">
           <div className="flex flex-1 flex-col h-full">
             <Tab.Group selectedIndex={selectedIndex} onChange={setSelectedIndex}>

--- a/frontend/components/Blocks/SectionBlock/CostBenefitModal/CostBenefitModal.tsx
+++ b/frontend/components/Blocks/SectionBlock/CostBenefitModal/CostBenefitModal.tsx
@@ -51,7 +51,7 @@ export default function CostBenefitModal({ handleClose, costBenefitData, graphco
 
   return (
     <div className="h-screen bg-white">
-      <div className="bg-white py-6 px-10 lg:px-16 fixed top-[4.5rem] md:top-28 inset-x-0 mx-auto h-[calc(100%-4.5rem)] md:h-[calc(100%-7rem)] z-20">
+      <div className="bg-white py-6 px-10 lg:px-16 fixed top-20 md:top-[5.7rem] inset-x-0 mx-auto h-[calc(100%-4.5rem)] md:h-[calc(100%-7rem)] z-30">
         <div className="block h-full w-full">
           <div className="flex flex-1 flex-col h-full">
             <Tab.Group selectedIndex={selectedIndex} onChange={setSelectedIndex}>

--- a/frontend/components/Blocks/SectionBlock/HolarchyTab/HolarchyTab.tsx
+++ b/frontend/components/Blocks/SectionBlock/HolarchyTab/HolarchyTab.tsx
@@ -41,7 +41,7 @@ export default function HolarchyTab({
 
   return (
     <div className="w-screen h-screen bg-white">
-      <div className="bg-white fixed top-[4.5rem] md:top-[6.4rem] overflow-auto md:overflow-hidden inset-x-0 mx-auto h-[calc(100%-4.5rem)] md:h-[calc(100%-9.5rem)] w-screen z-10 mt-14 grid grid-rows-9 grid-cols-1 md:grid-cols-3 md:grid-rows-3 ">
+      <div className="bg-white fixed top-[5rem] md:top-[5.2rem] overflow-auto md:overflow-hidden inset-x-0 mx-auto h-[calc(100%-4.5rem)] md:h-[calc(100%-9.5rem)] w-screen z-10 mt-14 grid grid-rows-9 grid-cols-1 md:grid-cols-3 md:grid-rows-3 ">
         {/*Interactive input -  left column */}
         {levels.map((level, index) => {
           const cssClasses = [

--- a/frontend/components/Blocks/SectionBlock/HolarchyTab/HolarchyTab.tsx
+++ b/frontend/components/Blocks/SectionBlock/HolarchyTab/HolarchyTab.tsx
@@ -41,7 +41,7 @@ export default function HolarchyTab({
 
   return (
     <div className="w-screen h-screen bg-white">
-      <div className="bg-white fixed top-[5rem] md:top-[5.2rem] overflow-auto md:overflow-hidden inset-x-0 mx-auto h-[calc(100%-4.5rem)] md:h-[calc(100%-9.5rem)] w-screen z-10 mt-14 grid grid-rows-9 grid-cols-1 md:grid-cols-3 md:grid-rows-3 ">
+      <div className="bg-white fixed top-[7.9rem] min-[700px]:top-[5.1rem] overflow-auto md:overflow-hidden inset-x-0 mx-auto h-[calc(100%-11rem)] min-[700px]:h-[calc(100%-8rem)] w-screen z-15 mt-14 grid grid-rows-9 grid-cols-1 md:grid-cols-3 md:grid-rows-3 ">
         {/*Interactive input -  left column */}
         {levels.map((level, index) => {
           const cssClasses = [

--- a/frontend/components/Blocks/SectionBlock/SectionBlock.tsx
+++ b/frontend/components/Blocks/SectionBlock/SectionBlock.tsx
@@ -29,7 +29,7 @@ type Props = {
       textLabelIntermediate: string;
       textLabelLocal: string;
       gridLayout: GridLayout;
-      openingSection?: boolean; 
+      openingSection?: boolean;
     };
     id: string;
   };
@@ -38,7 +38,7 @@ type Props = {
   graphcolors?: Graphcolor[];
   savePageValues: React.Dispatch<React.SetStateAction<SavedElements>>;
   saveScenario: (title: string, description: string, sectionId: string) => string;
-  scenarioDiffElements: object; 
+  scenarioDiffElements: object;
 };
 
 const initialData = {
@@ -68,7 +68,7 @@ export default function SectionBlock({
   graphcolors,
   savePageValues,
   saveScenario,
-  scenarioDiffElements
+  scenarioDiffElements,
 }: Props) {
   const [kpis, setKPIs] = useState(initialData);
   const [costBenefitData, setCostBenefitData] = useState({});
@@ -136,7 +136,6 @@ export default function SectionBlock({
         }, 500);
       }
     }
-    
   }, [content, debouncedCalculateKPIs]);
 
   useEffect(() => {
@@ -251,26 +250,29 @@ export default function SectionBlock({
       if (sectionItem.type === "interactive_input" && sectionItem.value.visible) {
         const key = `${sectionItem.value.id}`;
         const value = sectionItem.currentValue;
-        const name = sectionItem.value.name; 
+        const name = sectionItem.value.name;
 
-        savedElements[data.id] = { ...savedElements[data.id], [key]: {
-          value: value, 
-          name: name,
-        }}
+        savedElements[data.id] = {
+          ...savedElements[data.id],
+          [key]: {
+            value: value,
+            name: name,
+          },
+        };
       }
     });
     return savedElements;
   };
 
   async function handleSaveScenario(title: string, description: string) {
-    const url = saveScenario(title, description, data.id); 
-    const shorturl = await createTinyUrl(url)
+    const url = saveScenario(title, description, data.id);
+    const shorturl = await createTinyUrl(url);
 
     setSavedScenarioURL(shorturl);
-    setScenarioModalType("savedScenario");    
-    return; 
-    } 
-  
+    setScenarioModalType("savedScenario");
+    return;
+  }
+
   return (
     <div className={`sectionContainer`} ref={sectionContainerRef} id={data.id}>
       {feedbackmodals && (
@@ -298,7 +300,7 @@ export default function SectionBlock({
 
       <div className="holonContentContainer">
         {pagetype !== "Sandbox" && (
-          <div className="sticky z-10 top-[87px] flex flex-row items-center md:top-[90px] bg-white px-10 lg:px-16 pl-4 shadow-md ">
+          <div className="sticky z-30 top-[87px] flex flex-row items-center md:top-[90px] bg-white px-10 lg:px-16 pl-4 shadow-[0_4px_2px_-2px_rgba(0,0,0,0.3)]">
             <div className="flex-1">
               <button
                 onClick={closeHolarchyModal}
@@ -356,7 +358,7 @@ export default function SectionBlock({
 
           <div className={`relative flex flex-col ${gridValue.right}`}>
             {dirtyState && (
-              <div className="absolute flex justify-center items-center p-12 top-0 left-0 w-full h-full bg-black/[.8] z-50">
+              <div className="absolute flex justify-center items-center p-12 top-0 left-0 w-full h-full bg-black/[.8] z-20">
                 <div className="bg-white p-12 w-50 inline-block mx-auto h-auto rounded">
                   <div>
                     <h2>Reken instellingen door</h2>

--- a/frontend/components/Blocks/SectionBlock/SectionBlock.tsx
+++ b/frontend/components/Blocks/SectionBlock/SectionBlock.tsx
@@ -300,7 +300,7 @@ export default function SectionBlock({
 
       <div className="holonContentContainer">
         {pagetype !== "Sandbox" && (
-          <div className="sticky z-30 top-[87px] flex flex-row items-center md:top-[90px] bg-white px-10 lg:px-16 pl-4 shadow-[0_4px_2px_-2px_rgba(0,0,0,0.3)]">
+          <div className="sticky z-20 top-[87px] flex flex-row items-center md:top-[90px] bg-white px-10 lg:px-16 pl-4 shadow-[0_3px_2px_-2px_rgba(0,0,0,0.3)]">
             <div className="flex-1">
               <button
                 onClick={closeHolarchyModal}


### PR DESCRIPTION
This issue addresses #792. 
This had to do with the new height of the header and not with the sandbox page. I've also adjusted the distance to the header in the section menu bar, the holarchy tab and the kostenbaten view. Next to that I've also adjusted the z-index of a few items so they overlap correctly and the shadow box of the section menu bar is now only showing below (relevant for big screens). 