### PR TITLE
Use scenario aggregate in cost table

### DIFF
--- a/src/holon/tests/rule_actions/test_rule_action_change_attribute.py
+++ b/src/holon/tests/rule_actions/test_rule_action_change_attribute.py
@@ -253,3 +253,6 @@ class RuleMappingTestClass(TestCase):
         assert int(updated_scenario.repositories[ModelType.ACTOR.value].first().group_id) == int(
             actor_group.id
         )
+        assert int(updated_scenario.repositories[ModelType.ACTOR.value].first().group.id) == int(
+            actor_group.id
+        )

--- a/src/holon/tests/test_costs_table.py
+++ b/src/holon/tests/test_costs_table.py
@@ -1,5 +1,6 @@
 from django.test import TestCase
 from holon.models.scenario import Scenario
+from holon.rule_engine.scenario_aggregate import ScenarioAggregate
 from holon.services.costs_table import CostTables
 
 
@@ -9,7 +10,8 @@ class CostTableTestClass(TestCase):
     def test_table_totals(self):
         """Test if the totals table is correctly set up"""
         scenario = Scenario.objects.get(pk=1)
-        tables = CostTables.from_al_output(self.__al_output(), scenario)
+        scenario_aggregate = ScenarioAggregate(scenario)
+        tables = CostTables.from_al_output(self.__al_output(), scenario_aggregate)
         costs_table = tables.main_table()
 
         assert "Bedrijventerrein HOLON" in costs_table.keys()

--- a/src/holon/views/holon.py
+++ b/src/holon/views/holon.py
@@ -44,7 +44,7 @@ class HolonV2Service(generics.CreateAPIView):
     def post(self, request: Request):
         serializer = HolonRequestSerializer(data=request.data)
 
-        use_caching = use_result_cache(request)
+        use_caching = False  # use_result_cache(request)
         scenario = None
         cc_payload = None
         cc = None
@@ -92,7 +92,7 @@ class HolonV2Service(generics.CreateAPIView):
 
                 HolonV2Service.logger.log_print("Calculating CostTables")
                 cost_benefit_tables = self._cost_benefit_tables(
-                    etm_outcomes.pop("depreciation_costs"), scenario, cc
+                    etm_outcomes.pop("depreciation_costs"), scenario_aggregate, cc
                 )
 
                 results = Results(
@@ -161,9 +161,9 @@ class HolonV2Service(generics.CreateAPIView):
         return etm_outcomes
 
     def _cost_benefit_tables(
-        self, depreciation_costs, scenario: Scenario, cc: CloudClient
+        self, depreciation_costs, scenario_aggregate: ScenarioAggregate, cc: CloudClient
     ) -> CostTables:
-        tables = CostTables.from_al_output(self._find_contracts(cc), scenario)
+        tables = CostTables.from_al_output(self._find_contracts(cc), scenario_aggregate)
         for costs in depreciation_costs:
             tables.inject_depreciation_costs(costs)
         return tables

--- a/src/holon/views/holon.py
+++ b/src/holon/views/holon.py
@@ -44,7 +44,7 @@ class HolonV2Service(generics.CreateAPIView):
     def post(self, request: Request):
         serializer = HolonRequestSerializer(data=request.data)
 
-        use_caching = False  # use_result_cache(request)
+        use_caching = use_result_cache(request)
         scenario = None
         cc_payload = None
         cc = None


### PR DESCRIPTION
Use scenario aggregate in cost table. This solves the issue where newly added actors can't be found, since the rule engine works in memory now.