### PR TITLE
Log anylogic output

### DIFF
--- a/src/pipit/sentry.py
+++ b/src/pipit/sentry.py
@@ -26,7 +26,7 @@ def initialize_sentry(ingest_dsn: str, environment: str) -> None:
                 middleware_spans=False,
                 # Wagtail produces a lot of signals
                 signals_spans=False,
-            )
+            ),
         ],
         release="0.1.0",
         # We do too many queries on some pages.


### PR DESCRIPTION
Log anylogic input and output to Sentry if tracing is enabled. This allows to debug and validate the scenarios.

Sample output: https://zenmo.sentry.io/performance/holon:6922a42c31d64a8a81d7655c88e4d1b6/?environment=erik&project=4505045759361024&query=http.method%3APOST&referrer=performance-transaction-summary&statsPeriod=1h&transaction=%2Fwt%2Fapi%2Fnextjs%2Fv2%2Fholon%2F&unselectedSeries=p100%28%29
    
(check the metadata of CloudClient.run)
