### PR TITLE
rule engine: load all actor groups

### DIFF
--- a/src/holon/rule_engine/repositories/actor_group_repository.py
+++ b/src/holon/rule_engine/repositories/actor_group_repository.py
@@ -10,4 +10,9 @@ class ActorGroupRepository(RepositoryBaseClass):
 
     @classmethod
     def from_scenario(cls, scenario: Scenario):
-        return cls(list(ActorGroup.objects.filter(actor__payload=scenario).distinct()))
+        raise NotImplementedError("Actor groups are shared by all scenarios")
+
+    @classmethod
+    def full(cls):
+        """Load all ActorGroups: rule actions can assign actors to groups which aren't in the base scenario"""
+        return cls(list(ActorGroup.objects.all()))

--- a/src/holon/rule_engine/repositories/actor_sub_group_repository.py
+++ b/src/holon/rule_engine/repositories/actor_sub_group_repository.py
@@ -10,4 +10,9 @@ class ActorSubGroupRepository(RepositoryBaseClass):
 
     @classmethod
     def from_scenario(cls, scenario: Scenario):
-        return cls(list(ActorSubGroup.objects.filter(actor__payload=scenario).distinct()))
+        raise NotImplementedError("Actor sub groups are shared by all scenarios")
+
+    @classmethod
+    def full(cls):
+        """Load all ActorSubGroups: rule actions can assign actors to groups which aren't in the base scenario"""
+        return cls(list(ActorSubGroup.objects.all()))

--- a/src/holon/rule_engine/scenario_aggregate.py
+++ b/src/holon/rule_engine/scenario_aggregate.py
@@ -37,11 +37,8 @@ class ScenarioAggregate:
 
         self.repositories: dict[str, RepositoryBaseClass] = {
             ModelType.ACTOR.value: ActorRepository.from_scenario(self.scenario),
-            # We could also inspect the actors and get the group and subgroup id's from there
-            # and use those to initialize the repositories.
-            # The database is probably faster at doing that.
-            ModelType.ACTOR_GROUP.value: ActorGroupRepository.from_scenario(self.scenario),
-            ModelType.ACTOR_SUB_GROUP.value: ActorSubGroupRepository.from_scenario(self.scenario),
+            ModelType.ACTOR_GROUP.value: ActorGroupRepository.full(),
+            ModelType.ACTOR_SUB_GROUP.value: ActorSubGroupRepository.full(),
             ModelType.ENERGYASSET.value: EnergyAssetRepository.from_scenario(self.scenario),
             ModelType.CONTRACT.value: ContractRepository.from_scenario(self.scenario),
             ModelType.POLICY.value: PolicyRepository.from_scenario(self.scenario),


### PR DESCRIPTION
Load all actor groups and subgroups for usage by the rule engine. This fixes casus transitievisie warmte.