### PR TITLE
Update pk when adding instances to a repository

### DIFF
--- a/src/holon/rule_engine/repositories/repository_base.py
+++ b/src/holon/rule_engine/repositories/repository_base.py
@@ -227,7 +227,7 @@ class RepositoryBaseClass:
 
         # copy object and set new id
         cloned_new_object = deepcopy(new_object)
-        cloned_new_object.id = next(self.id_counter)
+        cloned_new_object.pk = cloned_new_object.id = next(self.id_counter)
 
         # add new object to list and return new object
         self.objects.append(cloned_new_object)

--- a/src/holon/tests/aggregate/test_add.py
+++ b/src/holon/tests/aggregate/test_add.py
@@ -91,7 +91,6 @@ class ScenarioAggregateAddTestClass(TestCase):
             eta_r=0.95,
             deliveryTemp_degC=70.0,
             capacityElectricity_kW=30.0,
-            id=5,
         )
 
         self.assertRaises(
@@ -106,6 +105,7 @@ class ScenarioAggregateAddTestClass(TestCase):
         ) == new_object
 
         assert self.scenario_aggregate.repositories[ModelType.ENERGYASSET.value].len() == 5
+        assert new_object != asset5
 
     def test_add_empty_repo_type(self):
         gridnode = GridNode(id=22)


### PR DESCRIPTION
By updating the pk field when adding instances to a repository, objects are not wrongly considered equal anymore.

Before when adding multiple template instances to a repository all were considered equal, because only the id field was updated and Django. This caused the set() function used for merging repositories to remove too much instances.

Kudos to @thesethtruth for debugging :)

Closes #820 