### PR TITLE
Table thousand separators

### DIFF
--- a/frontend/components/CostBenefit/CostBenefitTable.tsx
+++ b/frontend/components/CostBenefit/CostBenefitTable.tsx
@@ -1,6 +1,14 @@
 import { ArrowDownIcon } from "@heroicons/react/24/outline";
 import styles from "./CostBenefit.module.css";
 
+const numberFormatter = new Intl.NumberFormat(
+    'nl-NL', {
+      style: 'currency',
+      currency: 'EUR',
+      maximumFractionDigits: 0,
+      maximumSignificantDigits: 4
+    })
+
 export default function CostBenefitTable({ tableData }: { tableData: Array<object> }) {
   const backgroundCell = {
     pos: "bg-holon-light-green",
@@ -30,11 +38,15 @@ export default function CostBenefitTable({ tableData }: { tableData: Array<objec
   function valueCheck(value: number | undefined) {
     if (!value) {
       return "-";
-    } else if (value >= 0) {
-      return "€ " + value;
-    } else if (value < 0) {
-      return "-€ " + Math.abs(value);
     }
+
+    let sign = "";
+    if (value < 0) {
+        sign = "-";
+        value = Math.abs(value);
+    }
+
+    return sign + ' ' + numberFormatter.format(value);
   }
 
   const popUp = (labelText: number, innerText: string) => {


### PR DESCRIPTION
Add thousand separators to cost-benefit tables. Also round numbers to 4 significant digits. Less significant digits are displayed as 0.

Closes #884