### PR TITLE
Cost-benefit graph: move label

### DIFF
--- a/frontend/components/Blocks/SectionBlock/CostBenefitModal/CostBenefitModal.tsx
+++ b/frontend/components/Blocks/SectionBlock/CostBenefitModal/CostBenefitModal.tsx
@@ -8,6 +8,14 @@ import { XMarkIcon } from "@heroicons/react/24/outline";
 import classNames from "classnames";
 import { useEffect, useState } from "react";
 
+export const euroFormatter = new Intl.NumberFormat(
+    'nl-NL', {
+      style: 'currency',
+      currency: 'EUR',
+      maximumFractionDigits: 0,
+      maximumSignificantDigits: 4
+    })
+
 type Props = {
   handleClose: () => void;
   costBenefitData: {

--- a/frontend/components/CostBenefit/CostBenefitChart.tsx
+++ b/frontend/components/CostBenefit/CostBenefitChart.tsx
@@ -1,3 +1,4 @@
+import {euroFormatter} from '@/components/Blocks/SectionBlock/CostBenefitModal/CostBenefitModal'
 import React from "react";
 
 import {
@@ -29,9 +30,8 @@ export default function CostBenefitChart({
     );
   };
 
-  const convertToPositiveEuro = (tickItem: number) => {
-    return "€ " + Math.abs(tickItem);
-  };
+  const convertToPositiveEuro = (tickItem: number) =>
+    euroFormatter.format(Math.abs(tickItem));
 
   const values = chartdata.flatMap(innerArr => Object.values(innerArr).flat());
   const numberValues = values.map(Number).filter(Number.isFinite);
@@ -82,12 +82,12 @@ export default function CostBenefitChart({
               margin={{ top: 0, right: 0, left: 0, bottom: 0 }}>
               <CartesianGrid strokeDasharray="2" vertical={false} />
               <XAxis orientation="top" dataKey="name" axisLine={false} />
-              <YAxis tickFormatter={convertToPositiveEuro} domain={[newMin, newMax]}>
+              <YAxis tickFormatter={convertToPositiveEuro} width={120} domain={[newMin, newMax]}>
                 <Label
                   position="center"
                   angle={-90}
                   value="← Kosten &nbsp;  &nbsp; &nbsp; &nbsp;  Baten &nbsp;  →"
-                  dx={-25}
+                  dx={-45}
                 />
               </YAxis>
               <Tooltip content={<CustomTooltip />} itemSorter={item => item.value} />

--- a/frontend/components/CostBenefit/CostBenefitTable.tsx
+++ b/frontend/components/CostBenefit/CostBenefitTable.tsx
@@ -1,13 +1,6 @@
+import {euroFormatter} from '@/components/Blocks/SectionBlock/CostBenefitModal/CostBenefitModal'
 import { ArrowDownIcon } from "@heroicons/react/24/outline";
 import styles from "./CostBenefit.module.css";
-
-const numberFormatter = new Intl.NumberFormat(
-    'nl-NL', {
-      style: 'currency',
-      currency: 'EUR',
-      maximumFractionDigits: 0,
-      maximumSignificantDigits: 4
-    })
 
 export default function CostBenefitTable({ tableData }: { tableData: Array<object> }) {
   const backgroundCell = {
@@ -46,7 +39,7 @@ export default function CostBenefitTable({ tableData }: { tableData: Array<objec
         value = Math.abs(value);
     }
 
-    return sign + ' ' + numberFormatter.format(value);
+    return sign + ' ' + euroFormatter.format(value);
   }
 
   const popUp = (labelText: number, innerText: string) => {


### PR DESCRIPTION
Move the label "cost-benefit" so it no longer overlaps with the number scale of the Y axis.

Fixes https://github.com/ZEnMo/Holon-webapp/issues/876